### PR TITLE
Refactor DeckManager UI and card list retrieval

### DIFF
--- a/function/clas/card_list_screen.py
+++ b/function/clas/card_list_screen.py
@@ -69,8 +69,8 @@ class CardListScreen(MDScreen):
         self.current_deck_name = None
         self.title_label.text = "全カード一覧"
         self.grid.clear_widgets()
-        all_cards = self.db.get_all_cards()
-        for idx, (card_name, _) in enumerate(all_cards):
+        all_cards = self.db.get_all_card_names()
+        for idx, card_name in enumerate(all_cards):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
             label = MDLabel(text=card_name, halign="left", font_name=DEFAULT_FONT)
             delete_btn = MDIconButton(icon="delete", disabled=True)

--- a/function/clas/deck_manager.py
+++ b/function/clas/deck_manager.py
@@ -1,12 +1,8 @@
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDRaisedButton, MDIconButton
-from kivymd.uix.label import MDLabel
-from kivymd.uix.textfield import MDTextField
+from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.dialog import MDDialog
-from kivymd.uix.scrollview import MDScrollView
 from kivy.metrics import dp
-from kivy.core.text import DEFAULT_FONT
 from function.core.db_handler import DBHandler
 import csv
 import os
@@ -18,70 +14,11 @@ class DeckManagerScreen(MDScreen):
         self.dialog = None
         self.current_import_deck = None
 
-        self.layout = MDBoxLayout(orientation="vertical", spacing=10, padding=10)
-
-        # タイトル
-        self.top_title = MDLabel(text="[デッキ管理]", halign="center", font_name=DEFAULT_FONT, size_hint_y=0.1)
-
-        # デッキ作成エリア
-        self.new_deck_row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(48))
-        self.new_deck_input = MDTextField(hint_text="新しいデッキ名", font_name=DEFAULT_FONT)
-        self.create_deck_button = MDRaisedButton(
-            text="デッキを作成",
-            on_press=self.create_deck,
-            md_bg_color=(0.4, 0.4, 0.6, 1),
-            size_hint_x=None,
-            width=dp(120)
-        )
-        self.new_deck_row.add_widget(self.new_deck_input)
-        self.new_deck_row.add_widget(self.create_deck_button)
-
-        # デッキリストエリア（スクロールビュー）
-        self.scroll_view = MDScrollView(size_hint=(1, 0.6))
-        self.deck_buttons_layout = MDBoxLayout(orientation="vertical", spacing=5, size_hint_y=None)
-        self.deck_buttons_layout.bind(minimum_height=self.deck_buttons_layout.setter("height"))
-        self.scroll_view.add_widget(self.deck_buttons_layout)
-
-        # CSVインポート行
-        self.import_row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(48))
-        self.import_path_input = MDTextField(hint_text="CSVファイルのパスを入力", font_name=DEFAULT_FONT, size_hint_x=0.7)
-        self.import_button = MDRaisedButton(
-            text="CSVからインポート",
-            on_press=self.import_deck_from_csv,
-            size_hint_x=0.3,
-            md_bg_color=(0.3, 0.6, 0.3, 1)
-        )
-        self.import_row.add_widget(self.import_path_input)
-        self.import_row.add_widget(self.import_button)
-
-        # 下部ボタン（横並び）
-        self.bottom_row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(48))
-        self.back_button = MDRaisedButton(
-            text="戻る",
-            on_press=self.go_back,
-            md_bg_color=(0.7, 0.2, 0.2, 1),
-            size_hint_x=0.5
-        )
-        self.all_cards_button = MDRaisedButton(
-            text="全てのカードを見る",
-            on_press=self.show_all_cards,
-            md_bg_color=(0.2, 0.6, 0.2, 1),
-            size_hint_x=0.5
-        )
-        self.bottom_row.add_widget(self.back_button)
-        self.bottom_row.add_widget(self.all_cards_button)
-
-        self.layout.add_widget(self.top_title)
-        self.layout.add_widget(self.new_deck_row)
-        self.layout.add_widget(self.scroll_view)
-        self.layout.add_widget(self.import_row)
-        self.layout.add_widget(self.bottom_row)
-
-        self.add_widget(self.layout)
+    def on_pre_enter(self, *args):
         self.refresh_deck_list()
 
     def refresh_deck_list(self):
-        self.deck_buttons_layout.clear_widgets()
+        self.ids.deck_buttons_layout.clear_widgets()
         decks = self.db.get_all_decks()
         for deck in decks:
             row = MDBoxLayout(orientation="horizontal", spacing=5, size_hint_y=None, height=dp(48))
@@ -109,13 +46,13 @@ class DeckManagerScreen(MDScreen):
             row.add_widget(deck_button)
             row.add_widget(import_icon)
             row.add_widget(delete_icon)
-            self.deck_buttons_layout.add_widget(row)
+            self.ids.deck_buttons_layout.add_widget(row)
 
     def create_deck(self, instance):
-        name = self.new_deck_input.text.strip()
+        name = self.ids.new_deck_input.text.strip()
         if name:
             self.db.add_deck(name)
-            self.new_deck_input.text = ""
+            self.ids.new_deck_input.text = ""
             self.refresh_deck_list()
             self.show_dialog("デッキを追加しました")
 
@@ -135,7 +72,7 @@ class DeckManagerScreen(MDScreen):
             self.show_dialog("先にインポート先のデッキを選択してください")
             return
 
-        path = self.import_path_input.text.strip()
+        path = self.ids.import_path_input.text.strip()
         if not os.path.isfile(path):
             self.show_dialog("無効なファイルパスです")
             return

--- a/function/core/db_handler.py
+++ b/function/core/db_handler.py
@@ -66,6 +66,13 @@ class DBHandler:
         self.cursor.execute("SELECT card_name, SUM(count) FROM deck_cards GROUP BY card_name")
         return self.cursor.fetchall()
 
+    def get_all_card_names(self):
+        """
+        cards_info テーブルからすべてのカード名を取得
+        """
+        self.cursor.execute("SELECT name_ja FROM cards_info ORDER BY name_ja")
+        return [row[0] for row in self.cursor.fetchall()]
+
     def add_card(self, deck_name, card_name, count):
         """
         デッキにカードを追加（既存なら加算）

--- a/main.py
+++ b/main.py
@@ -22,8 +22,9 @@ from function.clas.card_get_screen import CardInfoScreen  # ← 追加
 # 日本語フォント設定
 LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.ttf')
 
-# CardInfoScreen の .kv ファイル読み込み
+# CardInfoScreen, DeckManagerScreen の .kv ファイル読み込み
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
+Builder.load_file("resource/theme/gui/DeckManagerScreen.kv")
 
 class MenuScreen(MDScreen):
     def __init__(self, **kwargs):

--- a/resource/theme/gui/DeckManagerScreen.kv
+++ b/resource/theme/gui/DeckManagerScreen.kv
@@ -1,0 +1,75 @@
+#:import dp kivy.metrics.dp
+
+<DeckManagerScreen>:
+    MDBoxLayout:
+        orientation: 'vertical'
+        spacing: 10
+        padding: 10
+
+        MDLabel:
+            text: '[デッキ管理]'
+            halign: 'center'
+            size_hint_y: 0.1
+
+        MDBoxLayout:
+            id: new_deck_row
+            orientation: 'horizontal'
+            spacing: 10
+            size_hint_y: None
+            height: dp(48)
+            MDTextField:
+                id: new_deck_input
+                hint_text: '新しいデッキ名'
+            MDRaisedButton:
+                text: 'デッキを作成'
+                size_hint_x: None
+                width: dp(120)
+                md_bg_color: 0.4, 0.4, 0.6, 1
+                on_press: root.create_deck(self)
+            MDIconButton:
+                icon: 'refresh'
+                on_press: root.refresh_deck_list()
+                size_hint_x: None
+                width: dp(48)
+
+        MDScrollView:
+            size_hint: 1, 0.6
+            MDBoxLayout:
+                id: deck_buttons_layout
+                orientation: 'vertical'
+                spacing: 5
+                size_hint_y: None
+                height: self.minimum_height
+
+        MDBoxLayout:
+            id: import_row
+            orientation: 'horizontal'
+            spacing: 10
+            size_hint_y: None
+            height: dp(48)
+            MDTextField:
+                id: import_path_input
+                hint_text: 'CSVファイルのパスを入力'
+                size_hint_x: 0.7
+            MDRaisedButton:
+                text: 'CSVからインポート'
+                size_hint_x: 0.3
+                md_bg_color: 0.3, 0.6, 0.3, 1
+                on_press: root.import_deck_from_csv(self)
+
+        MDBoxLayout:
+            id: bottom_row
+            orientation: 'horizontal'
+            spacing: 10
+            size_hint_y: None
+            height: dp(48)
+            MDRaisedButton:
+                text: '戻る'
+                size_hint_x: 0.5
+                md_bg_color: 0.7, 0.2, 0.2, 1
+                on_press: root.go_back(self)
+            MDRaisedButton:
+                text: '全てのカードを見る'
+                size_hint_x: 0.5
+                md_bg_color: 0.2, 0.6, 0.2, 1
+                on_press: root.show_all_cards(self)


### PR DESCRIPTION
## Summary
- load kv layout for DeckManager and remove inline widget creation
- add refresh icon button to reload deck list
- pull all card names from `cards_info`
- update CardListScreen to use new DB method
- load new kv file in `main.py`

## Testing
- `python -m py_compile main.py function/clas/deck_manager.py function/clas/card_list_screen.py function/core/db_handler.py`

------
https://chatgpt.com/codex/tasks/task_e_687e3cb7162483338ab7a42224e21858