### PR TITLE
Add detailed card screen and count controls

### DIFF
--- a/function/clas/card_detail_screen.py
+++ b/function/clas/card_detail_screen.py
@@ -1,0 +1,39 @@
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.chip import MDChip
+from function.core.db_handler import DBHandler
+
+
+class CardDetailScreen(MDScreen):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.db = DBHandler()
+        self.card_name = ""
+
+    def load_card(self, card_name):
+        self.card_name = card_name
+        info = self.db.get_full_card_info(card_name) or {}
+        self.ids.name_label.text = card_name
+        self.ids.field_score.text = str(info.get("field_score", 0))
+        self.ids.hand_score.text = str(info.get("hand_score", 0))
+        self.ids.grave_score.text = str(info.get("grave_score", 0))
+        self.ids.card_text.text = info.get("card_text", "")
+        self.ids.card_info.text = info.get("info", "")
+        image = info.get("image_path") or ""
+        self.ids.card_image.source = image
+        self.ids.card_image.reload()
+        usage_box = self.ids.deck_usage
+        usage_box.clear_widgets()
+        for deck, count in self.db.get_deck_usage_for_card(card_name):
+            chip = MDChip(label=f"{deck} x{count}")
+            usage_box.add_widget(chip)
+
+    def save_scores(self):
+        try:
+            f = int(self.ids.field_score.text)
+            h = int(self.ids.hand_score.text)
+            g = int(self.ids.grave_score.text)
+            self.db.set_card_scores(self.card_name, field=f, hand=h, grave=g)
+        except ValueError:
+            pass
+        self.manager.current = "card_list"
+

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 from function.clas.deck_manager import DeckManagerScreen
 from function.clas.card_list_screen import CardListScreen
 from function.clas.card_get_screen import CardInfoScreen  # ← 追加
+from function.clas.card_detail_screen import CardDetailScreen
 
 # 日本語フォント設定
 LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.ttf')
@@ -25,6 +26,7 @@ LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.tt
 # CardInfoScreen, DeckManagerScreen の .kv ファイル読み込み
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
 Builder.load_file("resource/theme/gui/DeckManagerScreen.kv")
+Builder.load_file("resource/theme/gui/CardDetailScreen.kv")
 
 class MenuScreen(MDScreen):
     def __init__(self, **kwargs):
@@ -78,6 +80,7 @@ class DeckAnalyzerApp(MDApp):
         sm.add_widget(CardInfoScreen(name="card_info"))  # ← 追加
         sm.add_widget(DeckManagerScreen(name="deck"))
         sm.add_widget(CardListScreen(name="card_list"))
+        sm.add_widget(CardDetailScreen(name="card_detail"))
         sm.add_widget(MatchRegisterScreen(name="match"))
         sm.add_widget(StatsScreen(name="stats"))
         return sm

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -1,0 +1,80 @@
+<CardDetailScreen>:
+    BoxLayout:
+        orientation: 'vertical'
+        spacing: 10
+        padding: 10
+
+        MDLabel:
+            id: name_label
+            text: ''
+            halign: 'center'
+            font_style: 'H5'
+            size_hint_y: None
+            height: dp(40)
+
+        Image:
+            id: card_image
+            size_hint_y: 0.4
+            allow_stretch: True
+            source: ''
+
+        ScrollView:
+            size_hint_y: 0.3
+            MDLabel:
+                id: card_text
+                text: ''
+                font_name: DEFAULT_FONT
+                size_hint_y: None
+                height: self.texture_size[1]
+                text_size: self.width, None
+                halign: 'left'
+                valign: 'top'
+
+        MDLabel:
+            id: card_info
+            text: ''
+            theme_text_color: 'Secondary'
+            font_name: DEFAULT_FONT
+            size_hint_y: None
+            height: self.texture_size[1]
+            text_size: self.width, None
+            halign: 'left'
+
+        MDBoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: dp(48)
+            MDTextField:
+                id: field_score
+                hint_text: 'フィールド'
+                input_filter: 'int'
+            MDTextField:
+                id: hand_score
+                hint_text: '手札'
+                input_filter: 'int'
+            MDTextField:
+                id: grave_score
+                hint_text: '墓地'
+                input_filter: 'int'
+
+        ScrollView:
+            size_hint_y: 0.15
+            MDBoxLayout:
+                id: deck_usage
+                orientation: 'horizontal'
+                size_hint_y: None
+                height: self.minimum_height
+                spacing: 5
+
+        MDBoxLayout:
+            size_hint_y: None
+            height: dp(48)
+            spacing: 10
+            MDRaisedButton:
+                text: '戻る'
+                on_release: root.manager.current = 'card_list'
+                md_bg_color: 0.7, 0.2, 0.2, 1
+            MDRaisedButton:
+                text: '保存'
+                on_release: root.save_scores()
+                md_bg_color: 0.2, 0.6, 0.2, 1


### PR DESCRIPTION
## Summary
- add ability to adjust card counts in DB
- implement card detail screen with score editing
- show plus/minus buttons on deck card list
- move card detail view to new screen
- wire new screen into main application

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e40d4882883338932639ba113a1af