### PR TITLE
Add YAML DSL generator enhancements

### DIFF
--- a/function/core/effect_dsl_generator.py
+++ b/function/core/effect_dsl_generator.py
@@ -5,8 +5,16 @@ This module provides :func:`generate_effect_yaml` which converts official
 English card effect text into a YAML formatted DSL (schema v3).
 """
 
+import os
 import re
+import argparse
 from typing import List, Dict, Any
+
+# target パターン辞書読み込み
+try:
+    from .target_patterns import TARGET_PATTERNS
+except ImportError:  # スクリプト実行時の相対インポート対策
+    from target_patterns import TARGET_PATTERNS
 
 
 def split_effects(text: str) -> List[str]:
@@ -60,6 +68,43 @@ ACTION_PATTERNS = [
 ]
 
 
+class StoreNameGenerator:
+    """フィールドごとの store_as 名を自動生成するヘルパー"""
+
+    def __init__(self, effect_id: str):
+        self.effect_id = effect_id
+        self.counts: Dict[str, int] = {}
+
+    def next(self, field: str) -> str:
+        self.counts[field] = self.counts.get(field, 0) + 1
+        return f"{self.effect_id}_{field}_{self.counts[field]}"
+
+
+def extract_targets(text: str, gen: StoreNameGenerator) -> List[Dict[str, str]]:
+    """ターゲット候補を抽出して辞書リストを返す"""
+    results: List[Dict[str, str]] = []
+    for pat, sel in TARGET_PATTERNS.items():
+        if re.search(pat, text, re.IGNORECASE):
+            results.append({
+                "type": "explicit",
+                "select": sel,
+                "store_as": gen.next("target"),
+            })
+    return results
+
+
+def detect_branch_from_draw(text: str) -> List[str]:
+    """特定のドロー分岐パターンを検出し、アクションリストを返す"""
+    if re.search(r"draw 1 card\.\s*if it is a spell", text, re.IGNORECASE):
+        return [
+            "draw(1)",
+            'branch_from_draw(player.deck, store_as="drawn_card")',
+            'condition: drawn_card.type == "spell"',
+            "add_to_hand(drawn_card)",
+        ]
+    return []
+
+
 def extract_first(pattern_dict: Dict[str, str], text: str) -> str:
     for pattern, value in pattern_dict.items():
         if re.search(pattern, text, re.IGNORECASE):
@@ -79,6 +124,8 @@ def extract_list(patterns: List, text: str) -> List[str]:
 def parse_segment(segment: str, cid: str, index: int) -> Dict[str, Any]:
     effect_id = f"{cid}_{index}"
 
+    store_gen = StoreNameGenerator(effect_id)
+
     optional = bool(re.search(r"you can", segment, re.IGNORECASE))
     timing_type = "when" if re.search(r"\bwhen\b", segment, re.IGNORECASE) else "if"
     trigger = extract_first(TRIGGER_PATTERNS, segment)
@@ -93,7 +140,14 @@ def parse_segment(segment: str, cid: str, index: int) -> Dict[str, Any]:
     
     condition = extract_first(CONDITION_PATTERNS, cost_text)
     costs = extract_list(COST_PATTERNS, cost_text)
-    actions = extract_list(ACTION_PATTERNS, action_text)
+
+    branch_actions = detect_branch_from_draw(action_text)
+    if branch_actions:
+        actions = branch_actions
+    else:
+        actions = extract_list(ACTION_PATTERNS, action_text)
+
+    targets = extract_targets(segment, store_gen)
 
     return {
         "id": effect_id,
@@ -101,7 +155,7 @@ def parse_segment(segment: str, cid: str, index: int) -> Dict[str, Any]:
         "timing_type": timing_type,
         "optional": optional,
         "restriction": {"limit_per_turn": 1, "group": f"{cid}_group"},
-        "target": [],
+        "target": targets,
         "condition": condition,
         "cost": costs,
         "action": actions,
@@ -117,7 +171,7 @@ def dict_to_yaml(data: Dict[str, Any], indent: int = 0) -> List[str]:
             lines.extend(dict_to_yaml(value, indent + 1))
         elif isinstance(value, list):
             if not value:
-                lines.append(f"{pad}{key}: []")
+                lines.append(f"{pad}{key}: []  # ???")
             else:
                 lines.append(f"{pad}{key}:")
                 for item in value:
@@ -130,6 +184,9 @@ def dict_to_yaml(data: Dict[str, Any], indent: int = 0) -> List[str]:
             if isinstance(value, str):
                 import json
                 value_str = json.dumps(value)
+                if value == "":
+                    lines.append(f"{pad}{key}: {value_str}  # ???")
+                    continue
             elif isinstance(value, bool):
                 value_str = "true" if value else "false"
             else:
@@ -140,10 +197,44 @@ def dict_to_yaml(data: Dict[str, Any], indent: int = 0) -> List[str]:
 
 def generate_effect_yaml(cid: str, name: str, text: str) -> str:
     effects_raw = split_effects(text)
-    effects = [parse_segment(seg, cid, i + 1) for i, seg in enumerate(effects_raw)]
+    joined: List[str] = []
+    i = 0
+    while i < len(effects_raw):
+        seg = effects_raw[i]
+        if i + 1 < len(effects_raw):
+            combined = seg + ". " + effects_raw[i + 1]
+            if detect_branch_from_draw(combined):
+                joined.append(combined)
+                i += 2
+                continue
+        joined.append(seg)
+        i += 1
+
+    effects = [parse_segment(seg, cid, i + 1) for i, seg in enumerate(joined)]
     card_dict = {"cid": cid, "name": name, "effects": effects}
     yaml_lines = dict_to_yaml(card_dict)
     return "\n".join(yaml_lines) + "\n"
 
 
-__all__ = ["generate_effect_yaml"]
+def export_yaml(cid: str, yaml_text: str, out_dir: str = "./out") -> None:
+    """生成した YAML をファイルに保存する"""
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+    path = os.path.join(out_dir, f"{cid}.yaml")
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(yaml_text)
+
+
+__all__ = ["generate_effect_yaml", "export_yaml"]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Effect DSL YAML generator")
+    parser.add_argument("--cid", required=True, help="カードID")
+    parser.add_argument("--name", required=True, help="カード名")
+    parser.add_argument("--text", required=True, help="効果テキスト")
+    args = parser.parse_args()
+
+    yaml_text = generate_effect_yaml(args.cid, args.name, args.text)
+    print(yaml_text)
+    export_yaml(args.cid, yaml_text)

--- a/function/core/target_patterns.py
+++ b/function/core/target_patterns.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""target パターン定義ファイル
+
+Yu-Gi-Oh! のテキスト中のターゲット表現を簡易的にDSLへ変換するための
+パターンを保持する。
+"""
+
+TARGET_PATTERNS = {
+    r"1 monster from your GY": "player.graveyard.monster.choice(1)",
+    r"1 Spell from your hand": "player.hand.spell.choice(1)",
+}
+
+__all__ = ["TARGET_PATTERNS"]


### PR DESCRIPTION
## Summary
- add target pattern mapping in new helper `target_patterns.py`
- enhance `effect_dsl_generator.py` with automatic `store_as` naming and target detection
- support draw-branch actions and unresolved field comments
- join sentences for branch detection and export YAML per card via CLI

## Testing
- `python -m py_compile function/core/effect_dsl_generator.py function/core/target_patterns.py`
- `python function/core/effect_dsl_generator.py --cid=cid001 --name="Test" --text="Draw 1 card. If it is a Spell, add it to your hand."`
- `python function/core/effect_dsl_generator.py --cid=test2 --name="Test2" --text="Select 1 monster from your GY; Special Summon it."`

------
https://chatgpt.com/codex/tasks/task_e_687e46857aac83339c30d3b6ced28c3d