### PR TITLE
Add config screen and persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/external_resource
+/external_resource/*
+!/external_resource/config/
+!/external_resource/config/config.json
 /data/log

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pip install kivy kivymd pillow beautifulsoup4 selenium matplotlib
 1. Clone this repository.
 2. Ensure the `external_resource` directory exists (ignored by git) for the SQLite database and other exported data.
 3. (Optional) Place Japanese fonts under `resource/theme/font` if you need additional fonts.
+4. Default configuration is stored in `external_resource/config/config.json`. This file will be created automatically on first run if it does not exist.
 
 ## Running the Application
 
@@ -32,7 +33,7 @@ The main menu and deck management screens are launched from `main.py`:
 python3 main.py
 ```
 
-When started, the app displays a menu allowing you to manage decks, register match data or view statistics. Deck data is stored locally in an SQLite database under `external_resource/db/ygo_data.db`.
+When started, the app displays a menu allowing you to manage decks, register match data, view statistics or adjust application settings. Deck data is stored locally in an SQLite database under `external_resource/db/ygo_data.db`.
 
 ## Additional Tools
 

--- a/external_resource/config/config.json
+++ b/external_resource/config/config.json
@@ -1,0 +1,6 @@
+{
+  "animation_speed": 1.0,
+  "max_display_cards": 50,
+  "font_size_base": 16,
+  "theme_color": "Blue"
+}

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -1,0 +1,48 @@
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.picker import MDThemePicker
+from kivy.lang import Builder
+from kivy.properties import ObjectProperty
+from kivymd.app import MDApp
+from function.core.config_handler import ConfigHandler, DEFAULT_CONFIG
+
+Builder.load_file("resource/theme/gui/ConfigScreen.kv")
+
+class ConfigScreen(MDScreen):
+    config_handler: ConfigHandler = ObjectProperty()
+    _theme_menu = None
+
+    def on_pre_enter(self, *args):
+        self.load_values()
+
+    def load_values(self) -> None:
+        cfg = self.config_handler.config
+        self.ids.animation_speed.text = str(cfg.get("animation_speed", ""))
+        self.ids.max_display_cards.text = str(cfg.get("max_display_cards", ""))
+        self.ids.font_size_base.text = str(cfg.get("font_size_base", ""))
+        self.ids.theme_color_label.text = cfg.get("theme_color", "Blue")
+
+    def open_theme_picker(self):
+        picker = MDThemePicker()
+        picker.bind(on_select_color=self.on_theme_selected)
+        picker.open()
+
+    def on_theme_selected(self, instance, value):
+        palette = value.name.capitalize() if hasattr(value, "name") else str(value)
+        self.ids.theme_color_label.text = palette
+        MDApp.get_running_app().theme_cls.primary_palette = palette
+
+    def save_config(self):
+        cfg = self.config_handler.config
+        cfg["animation_speed"] = float(self.ids.animation_speed.text or 0)
+        cfg["max_display_cards"] = int(self.ids.max_display_cards.text or 0)
+        cfg["font_size_base"] = float(self.ids.font_size_base.text or 0)
+        cfg["theme_color"] = self.ids.theme_color_label.text
+        self.config_handler.save()
+
+    def reset_config(self):
+        self.config_handler.reset()
+        self.load_values()
+        MDApp.get_running_app().theme_cls.primary_palette = DEFAULT_CONFIG["theme_color"]
+
+    def go_back(self):
+        self.manager.current = "menu"

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -1,0 +1,37 @@
+import json
+import os
+from typing import Any, Dict
+
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "animation_speed": 1.0,
+    "max_display_cards": 50,
+    "font_size_base": 16,
+    "theme_color": "Blue",
+}
+
+class ConfigHandler:
+    def __init__(self, path: str = "external_resource/config/config.json"):
+        self.path = path
+        self.config: Dict[str, Any] = DEFAULT_CONFIG.copy()
+        self.load()
+
+    def load(self) -> None:
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, dict):
+                    self.config.update(data)
+            except Exception:
+                pass
+        else:
+            self.save()
+
+    def save(self) -> None:
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.config, f, ensure_ascii=False, indent=2)
+
+    def reset(self) -> None:
+        self.config = DEFAULT_CONFIG.copy()
+        self.save()

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ from function.clas.deck_manager import DeckManagerScreen
 from function.clas.card_list_screen import CardListScreen
 from function.clas.card_get_screen import CardInfoScreen  # ← 追加
 from function.clas.card_detail_screen import CardDetailScreen
+from function.clas.config_screen import ConfigScreen
+from function.core.config_handler import ConfigHandler
 
 # 日本語フォント設定
 LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.ttf')
@@ -27,6 +29,7 @@ LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.tt
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
 Builder.load_file("resource/theme/gui/DeckManagerScreen.kv")
 Builder.load_file("resource/theme/gui/CardDetailScreen.kv")
+Builder.load_file("resource/theme/gui/ConfigScreen.kv")
 
 class MenuScreen(MDScreen):
     def __init__(self, **kwargs):
@@ -39,6 +42,7 @@ class MenuScreen(MDScreen):
         layout.add_widget(MDRaisedButton(text="デッキ管理", on_press=lambda x: self.change_screen("deck")))
         layout.add_widget(MDRaisedButton(text="試合データ登録", on_press=lambda x: self.change_screen("match")))
         layout.add_widget(MDRaisedButton(text="統計表示", on_press=lambda x: self.change_screen("stats")))
+        layout.add_widget(MDRaisedButton(text="設定", on_press=lambda x: self.change_screen("config")))
         layout.add_widget(MDRaisedButton(text="終了", on_press=self.exit_app))
 
         self.add_widget(layout)
@@ -73,8 +77,12 @@ class StatsScreen(MDScreen):
         self.manager.current = screen_name
 
 class DeckAnalyzerApp(MDApp):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.config_handler = ConfigHandler()
+
     def build(self):
-        self.theme_cls.primary_palette = "BlueGray"
+        self.theme_cls.primary_palette = self.config_handler.config.get("theme_color", "Blue")
         sm = MDScreenManager()
         sm.add_widget(MenuScreen(name="menu"))
         sm.add_widget(CardInfoScreen(name="card_info"))  # ← 追加
@@ -83,6 +91,9 @@ class DeckAnalyzerApp(MDApp):
         sm.add_widget(CardDetailScreen(name="card_detail"))
         sm.add_widget(MatchRegisterScreen(name="match"))
         sm.add_widget(StatsScreen(name="stats"))
+        config_screen = ConfigScreen(name="config")
+        config_screen.config_handler = self.config_handler
+        sm.add_widget(config_screen)
         return sm
 
 if __name__ == '__main__':

--- a/resource/theme/gui/ConfigScreen.kv
+++ b/resource/theme/gui/ConfigScreen.kv
@@ -1,0 +1,55 @@
+#:import dp kivy.metrics.dp
+<ConfigScreen>:
+    BoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(10)
+
+        MDLabel:
+            text: '設定'
+            halign: 'center'
+            size_hint_y: None
+            height: dp(40)
+
+        MDTextField:
+            id: animation_speed
+            hint_text: 'アニメーション速度'
+            input_filter: 'float'
+
+        MDTextField:
+            id: max_display_cards
+            hint_text: '最大表示カード数'
+            input_filter: 'int'
+
+        MDTextField:
+            id: font_size_base
+            hint_text: '使用フォントサイズ'
+            input_filter: 'float'
+
+        BoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: dp(48)
+            MDLabel:
+                id: theme_color_label
+                text: 'Blue'
+                size_hint_x: 0.5
+                valign: 'center'
+            MDRaisedButton:
+                text: 'テーマ変更'
+                size_hint_x: 0.5
+                on_release: root.open_theme_picker()
+
+        BoxLayout:
+            size_hint_y: None
+            height: dp(48)
+            spacing: dp(10)
+            MDRaisedButton:
+                text: '保存'
+                on_release: root.save_config()
+            MDRaisedButton:
+                text: 'リセット'
+                on_release: root.reset_config()
+            MDRaisedButton:
+                text: '戻る'
+                on_release: root.go_back()


### PR DESCRIPTION
## Summary
- implement configuration file handler
- add ConfigScreen widget and kv layout
- integrate ConfigScreen into the app and menu
- provide default config JSON and update README
- adjust .gitignore to keep configuration files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e4a3037ec833381911b7d7335c168