### PR TITLE
Add DSL edit screen

### DIFF
--- a/function/clas/card_detail_screen.py
+++ b/function/clas/card_detail_screen.py
@@ -1,6 +1,8 @@
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.chip import MDChip
 from function.core.db_handler import DBHandler
+from function.core.effect_dsl_generator import generate_effect_yaml
+import os
 
 
 class CardDetailScreen(MDScreen):
@@ -36,4 +38,25 @@ class CardDetailScreen(MDScreen):
         except ValueError:
             pass
         self.manager.current = "card_list"
+
+    def open_effect_editor(self):
+        """Generate temporary YAML and open the effect edit screen."""
+        info = self.db.get_full_card_info(self.card_name)
+        if not info:
+            return
+        cid = info.get("cid")
+        text = info.get("card_text", "")
+        yaml_dir = os.path.join("external_resource", "effect_yaml")
+        os.makedirs(yaml_dir, exist_ok=True)
+        path = os.path.join(yaml_dir, f"{cid}.yaml")
+        try:
+            yaml_text = generate_effect_yaml(cid, self.card_name, text)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(yaml_text)
+        except Exception:
+            pass
+
+        edit_screen = self.manager.get_screen("card_effect_edit")
+        edit_screen.load_yaml(cid)
+        self.manager.current = "card_effect_edit"
 

--- a/function/clas/card_effect_edit_screen.py
+++ b/function/clas/card_effect_edit_screen.py
@@ -1,0 +1,64 @@
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.dialog import MDDialog
+import os
+
+class CardEffectEditScreen(MDScreen):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.cid = None
+        self.dialog = None
+
+    def load_yaml(self, cid: str):
+        """Load YAML file for the given card id and display it."""
+        self.cid = cid
+        path = os.path.join("external_resource", "effect_yaml", f"{cid}.yaml")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = f.read()
+        except FileNotFoundError:
+            data = ""
+        self.ids.yaml_field.text = data
+        self.ids.file_path_input.text = path
+
+    def reload_yaml(self):
+        if self.cid:
+            self.load_yaml(self.cid)
+
+    def save_yaml(self):
+        if not self.cid:
+            return
+        path = os.path.join("external_resource", "effect_yaml", f"{self.cid}.yaml")
+        text = self.ids.yaml_field.text
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+        self._show_dialog("保存", "YAMLを保存しました")
+
+    def import_yaml(self):
+        path = self.ids.file_path_input.text.strip()
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+            self.ids.yaml_field.text = text
+        except Exception as e:
+            self._show_dialog("エラー", str(e))
+
+    def export_yaml(self):
+        path = self.ids.file_path_input.text.strip()
+        if not path:
+            return
+        text = self.ids.yaml_field.text
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(text)
+            self._show_dialog("エクスポート", "YAMLを書き出しました")
+        except Exception as e:
+            self._show_dialog("エラー", str(e))
+
+    def _show_dialog(self, title: str, text: str):
+        if self.dialog:
+            self.dialog.dismiss()
+        self.dialog = MDDialog(title=title, text=text)
+        self.dialog.open()

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from function.clas.deck_manager import DeckManagerScreen
 from function.clas.card_list_screen import CardListScreen
 from function.clas.card_get_screen import CardInfoScreen  # ← 追加
 from function.clas.card_detail_screen import CardDetailScreen
+from function.clas.card_effect_edit_screen import CardEffectEditScreen
 from function.clas.config_screen import ConfigScreen
 from function.core.config_handler import ConfigHandler
 
@@ -29,6 +30,7 @@ LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.tt
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
 Builder.load_file("resource/theme/gui/DeckManagerScreen.kv")
 Builder.load_file("resource/theme/gui/CardDetailScreen.kv")
+Builder.load_file("resource/theme/gui/CardEffectEditScreen.kv")
 Builder.load_file("resource/theme/gui/ConfigScreen.kv")
 
 class MenuScreen(MDScreen):
@@ -89,6 +91,7 @@ class DeckAnalyzerApp(MDApp):
         sm.add_widget(DeckManagerScreen(name="deck"))
         sm.add_widget(CardListScreen(name="card_list"))
         sm.add_widget(CardDetailScreen(name="card_detail"))
+        sm.add_widget(CardEffectEditScreen(name="card_effect_edit"))
         sm.add_widget(MatchRegisterScreen(name="match"))
         sm.add_widget(StatsScreen(name="stats"))
         config_screen = ConfigScreen(name="config")

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -75,6 +75,10 @@
                 on_release: root.manager.current = 'card_list'
                 md_bg_color: 0.7, 0.2, 0.2, 1
             MDRaisedButton:
+                text: 'カード効果を設定する'
+                on_release: root.open_effect_editor()
+                md_bg_color: 0.4, 0.4, 0.8, 1
+            MDRaisedButton:
                 text: '保存'
                 on_release: root.save_scores()
                 md_bg_color: 0.2, 0.6, 0.2, 1

--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -1,0 +1,49 @@
+#:import dp kivy.metrics.dp
+<CardEffectEditScreen>:
+    BoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(10)
+
+        MDLabel:
+            id: title_label
+            text: 'カード効果編集'
+            halign: 'center'
+            size_hint_y: None
+            height: dp(40)
+
+        MDScrollView:
+            MDTextField:
+                id: yaml_field
+                text: ''
+                multiline: True
+                size_hint_y: None
+                height: self.minimum_height
+                mode: 'rectangle'
+
+        MDTextField:
+            id: file_path_input
+            hint_text: 'ファイルパス'
+            size_hint_y: None
+            height: dp(40)
+
+        BoxLayout:
+            size_hint_y: None
+            height: dp(48)
+            spacing: dp(10)
+            MDRaisedButton:
+                text: '読込'
+                on_release: root.reload_yaml()
+            MDRaisedButton:
+                text: '保存'
+                on_release: root.save_yaml()
+            MDRaisedButton:
+                text: 'インポート'
+                on_release: root.import_yaml()
+            MDRaisedButton:
+                text: 'エクスポート'
+                on_release: root.export_yaml()
+            MDRaisedButton:
+                text: '戻る'
+                md_bg_color: 0.7,0.2,0.2,1
+                on_release: app.root.current = 'card_detail'


### PR DESCRIPTION
## Summary
- add card effect YAML editing screen
- generate YAML on-demand and open in editor
- wire screen into navigation

## Testing
- `python -m py_compile function/clas/card_effect_edit_screen.py function/clas/card_detail_screen.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e5ea3eb9c833391dd7a43c6e52e07