### PR TITLE
Implement theme config and move screens to kv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install kivy kivymd pillow beautifulsoup4 selenium matplotlib
 1. Clone this repository.
 2. Ensure the `external_resource` directory exists (ignored by git) for the SQLite database and other exported data.
 3. (Optional) Place Japanese fonts under `resource/theme/font` if you need additional fonts.
-4. Default configuration is stored in `external_resource/config/config.json`. This file will be created automatically on first run if it does not exist.
+4. Default configuration is stored in `external_resource/config/config.json`. This file will be created automatically on first run if it does not exist. You can edit this file to set the KivyMD color palette and theme style used by the application.
 
 ## Running the Application
 
@@ -34,6 +34,7 @@ python3 main.py
 ```
 
 When started, the app displays a menu allowing you to manage decks, register match data, view statistics or adjust application settings. Deck data is stored locally in an SQLite database under `external_resource/db/ygo_data.db`.
+The current color palette and light/dark style are loaded from `config.json` and can also be changed from the in-app settings screen.
 
 ## Additional Tools
 

--- a/external_resource/config/config.json
+++ b/external_resource/config/config.json
@@ -2,5 +2,6 @@
   "animation_speed": 1.0,
   "max_display_cards": 50,
   "font_size_base": 16,
-  "theme_color": "Blue"
+  "theme_color": "Blue",
+  "theme_style": "Light"
 }

--- a/function/clas/card_list_screen.py
+++ b/function/clas/card_list_screen.py
@@ -1,11 +1,8 @@
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.label import MDLabel
-from kivymd.uix.scrollview import MDScrollView
-from kivymd.uix.gridlayout import MDGridLayout
-from kivymd.uix.button import MDRaisedButton, MDIconButton
+from kivymd.uix.button import MDIconButton
 from kivymd.uix.card import MDCard
-from kivymd.uix.textfield import MDTextField
 from kivy.metrics import dp
 from function.core.db_handler import DBHandler
 from kivy.core.text import DEFAULT_FONT
@@ -17,34 +14,10 @@ class CardListScreen(MDScreen):
         self.db = DBHandler()
         self.current_deck_name = None
 
-        self.layout = MDBoxLayout(orientation='vertical', spacing=10, padding=10)
-
-        self.title_label = MDLabel(text="[カード一覧]", halign="center", font_name=DEFAULT_FONT, size_hint_y=0.15)
-        self.scroll = MDScrollView()
-        self.grid = MDGridLayout(cols=1, spacing=10, size_hint_y=None)
-        self.grid.bind(minimum_height=self.grid.setter('height'))
-        self.scroll.add_widget(self.grid)
-
-        self.input_row = MDBoxLayout(orientation='horizontal', spacing=10, size_hint_y=None, height=dp(48))
-        self.name_input = MDTextField(hint_text="カード名", font_name=DEFAULT_FONT, size_hint_x=0.5)
-        self.count_input = MDTextField(hint_text="枚数", input_filter='int', font_name=DEFAULT_FONT, size_hint_x=0.2)
-        self.add_button = MDRaisedButton(text="追加", on_press=self.add_card_to_deck, size_hint_x=0.3, md_bg_color=(0.2, 0.6, 0.2, 1))
-        self.input_row.add_widget(self.name_input)
-        self.input_row.add_widget(self.count_input)
-        self.input_row.add_widget(self.add_button)
-
-        self.back_button = MDRaisedButton(text="戻る", on_press=self.go_back, md_bg_color=(0.7, 0.2, 0.2, 1), size_hint_y=None, height=dp(48))
-
-        self.layout.add_widget(self.title_label)
-        self.layout.add_widget(self.scroll)
-        self.layout.add_widget(self.input_row)
-        self.layout.add_widget(self.back_button)
-        self.add_widget(self.layout)
-
     def load_deck(self, deck_name):
         self.current_deck_name = deck_name
-        self.title_label.text = f"デッキ: {deck_name} のカード一覧"
-        self.grid.clear_widgets()
+        self.ids.title_label.text = f"デッキ: {deck_name} のカード一覧"
+        self.ids.grid.clear_widgets()
         cards = self.db.get_cards_by_deck(deck_name)
         for idx, (card_name, count) in enumerate(cards):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
@@ -68,12 +41,12 @@ class CardListScreen(MDScreen):
 
             card = MDCard(row, size_hint_y=None, height=dp(50), padding=10, md_bg_color=bg_color)
             card.bind(on_release=lambda instance, name=card_name: self.open_card_detail(name))
-            self.grid.add_widget(card)
+            self.ids.grid.add_widget(card)
 
     def load_all_cards(self):
         self.current_deck_name = None
-        self.title_label.text = "全カード一覧"
-        self.grid.clear_widgets()
+        self.ids.title_label.text = "全カード一覧"
+        self.ids.grid.clear_widgets()
         all_cards = self.db.get_all_card_names()
         for idx, card_name in enumerate(all_cards):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
@@ -85,20 +58,20 @@ class CardListScreen(MDScreen):
 
             card = MDCard(row, size_hint_y=None, height=dp(50), padding=10, md_bg_color=bg_color)
             card.bind(on_release=lambda instance, name=card_name: self.open_card_detail(name))
-            self.grid.add_widget(card)
+            self.ids.grid.add_widget(card)
 
     def add_card_to_deck(self, instance):
-        card_name = self.name_input.text.strip()
+        card_name = self.ids.name_input.text.strip()
         try:
-            count = int(self.count_input.text.strip())
+            count = int(self.ids.count_input.text.strip())
         except ValueError:
             return
 
         if card_name and count > 0 and self.current_deck_name:
             self.db.add_card(self.current_deck_name, card_name, count)
             self.load_deck(self.current_deck_name)
-            self.name_input.text = ""
-            self.count_input.text = ""
+            self.ids.name_input.text = ""
+            self.ids.count_input.text = ""
 
     def delete_card_from_deck(self, card_name):
         if self.current_deck_name:

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -20,6 +20,7 @@ class ConfigScreen(MDScreen):
         self.ids.max_display_cards.text = str(cfg.get("max_display_cards", ""))
         self.ids.font_size_base.text = str(cfg.get("font_size_base", ""))
         self.ids.theme_color_label.text = cfg.get("theme_color", "Blue")
+        self.ids.theme_style_label.text = cfg.get("theme_style", "Light")
 
     def open_theme_picker(self):
         picker = MDThemePicker()
@@ -37,12 +38,20 @@ class ConfigScreen(MDScreen):
         cfg["max_display_cards"] = int(self.ids.max_display_cards.text or 0)
         cfg["font_size_base"] = float(self.ids.font_size_base.text or 0)
         cfg["theme_color"] = self.ids.theme_color_label.text
+        cfg["theme_style"] = self.ids.theme_style_label.text
         self.config_handler.save()
 
     def reset_config(self):
         self.config_handler.reset()
         self.load_values()
         MDApp.get_running_app().theme_cls.primary_palette = DEFAULT_CONFIG["theme_color"]
+        MDApp.get_running_app().theme_cls.theme_style = DEFAULT_CONFIG["theme_style"]
+
+    def toggle_theme_style(self):
+        current = self.ids.theme_style_label.text
+        new_style = "Dark" if current == "Light" else "Light"
+        self.ids.theme_style_label.text = new_style
+        MDApp.get_running_app().theme_cls.theme_style = new_style
 
     def go_back(self):
         self.manager.current = "menu"

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -7,6 +7,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "max_display_cards": 50,
     "font_size_base": 16,
     "theme_color": "Blue",
+    "theme_style": "Light",
 }
 
 class ConfigHandler:

--- a/main.py
+++ b/main.py
@@ -1,9 +1,6 @@
 from kivymd.app import MDApp
 from kivymd.uix.screenmanager import MDScreenManager
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.boxlayout import MDBoxLayout
-from kivymd.uix.label import MDLabel
-from kivymd.uix.button import MDRaisedButton
 from kivy.core.text import LabelBase, DEFAULT_FONT
 from kivy.core.window import Window
 from kivy.lang import Builder
@@ -32,23 +29,12 @@ Builder.load_file("resource/theme/gui/DeckManagerScreen.kv")
 Builder.load_file("resource/theme/gui/CardDetailScreen.kv")
 Builder.load_file("resource/theme/gui/CardEffectEditScreen.kv")
 Builder.load_file("resource/theme/gui/ConfigScreen.kv")
+Builder.load_file("resource/theme/gui/CardListScreen.kv")
+Builder.load_file("resource/theme/gui/MenuScreen.kv")
+Builder.load_file("resource/theme/gui/MatchRegisterScreen.kv")
+Builder.load_file("resource/theme/gui/StatsScreen.kv")
 
 class MenuScreen(MDScreen):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        layout = MDBoxLayout(orientation='vertical', spacing=10, padding=20)
-
-        layout.add_widget(MDLabel(text="デッキ分析ツール メインメニュー", halign="center", font_style="H5"))
-
-        layout.add_widget(MDRaisedButton(text="カード情報取得", on_press=lambda x: self.change_screen("card_info")))  # ← 追加
-        layout.add_widget(MDRaisedButton(text="デッキ管理", on_press=lambda x: self.change_screen("deck")))
-        layout.add_widget(MDRaisedButton(text="試合データ登録", on_press=lambda x: self.change_screen("match")))
-        layout.add_widget(MDRaisedButton(text="統計表示", on_press=lambda x: self.change_screen("stats")))
-        layout.add_widget(MDRaisedButton(text="設定", on_press=lambda x: self.change_screen("config")))
-        layout.add_widget(MDRaisedButton(text="終了", on_press=self.exit_app))
-
-        self.add_widget(layout)
-
     def change_screen(self, screen_name):
         self.manager.current = screen_name
 
@@ -57,24 +43,10 @@ class MenuScreen(MDScreen):
         Window.close()
 
 class MatchRegisterScreen(MDScreen):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        layout = MDBoxLayout(orientation='vertical', spacing=10, padding=20)
-        layout.add_widget(MDLabel(text="[試合データ登録画面]", halign="center"))
-        layout.add_widget(MDRaisedButton(text="戻る", on_press=lambda x: self.change_screen("menu")))
-        self.add_widget(layout)
-
     def change_screen(self, screen_name):
         self.manager.current = screen_name
 
 class StatsScreen(MDScreen):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        layout = MDBoxLayout(orientation='vertical', spacing=10, padding=20)
-        layout.add_widget(MDLabel(text="[統計表示画面]", halign="center"))
-        layout.add_widget(MDRaisedButton(text="戻る", on_press=lambda x: self.change_screen("menu")))
-        self.add_widget(layout)
-
     def change_screen(self, screen_name):
         self.manager.current = screen_name
 
@@ -84,7 +56,9 @@ class DeckAnalyzerApp(MDApp):
         self.config_handler = ConfigHandler()
 
     def build(self):
-        self.theme_cls.primary_palette = self.config_handler.config.get("theme_color", "Blue")
+        cfg = self.config_handler.config
+        self.theme_cls.primary_palette = cfg.get("theme_color", "Blue")
+        self.theme_cls.theme_style = cfg.get("theme_style", "Light")
         sm = MDScreenManager()
         sm.add_widget(MenuScreen(name="menu"))
         sm.add_widget(CardInfoScreen(name="card_info"))  # ← 追加

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -1,0 +1,54 @@
+#:import dp kivy.metrics.dp
+<CardListScreen>:
+    MDBoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(10)
+
+        MDLabel:
+            id: title_label
+            text: '[カード一覧]'
+            halign: 'center'
+            font_name: DEFAULT_FONT
+            size_hint_y: 0.15
+
+        MDScrollView:
+            id: scroll
+            MDGridLayout:
+                id: grid
+                cols: 1
+                spacing: dp(10)
+                size_hint_y: None
+                height: self.minimum_height
+
+        MDBoxLayout:
+            id: input_row
+            orientation: 'horizontal'
+            spacing: dp(10)
+            size_hint_y: None
+            height: dp(48)
+            MDTextField:
+                id: name_input
+                hint_text: 'カード名'
+                font_name: DEFAULT_FONT
+                size_hint_x: 0.5
+            MDTextField:
+                id: count_input
+                hint_text: '枚数'
+                input_filter: 'int'
+                font_name: DEFAULT_FONT
+                size_hint_x: 0.2
+            MDRaisedButton:
+                id: add_button
+                text: '追加'
+                size_hint_x: 0.3
+                md_bg_color: 0.2, 0.6, 0.2, 1
+                on_release: root.add_card_to_deck(self)
+
+        MDRaisedButton:
+            id: back_button
+            text: '戻る'
+            size_hint_y: None
+            height: dp(48)
+            md_bg_color: 0.7, 0.2, 0.2, 1
+            on_release: root.go_back(self)

--- a/resource/theme/gui/ConfigScreen.kv
+++ b/resource/theme/gui/ConfigScreen.kv
@@ -41,6 +41,20 @@
                 on_release: root.open_theme_picker()
 
         BoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: dp(48)
+            MDLabel:
+                id: theme_style_label
+                text: 'Light'
+                size_hint_x: 0.5
+                valign: 'center'
+            MDRaisedButton:
+                text: 'スタイル切替'
+                size_hint_x: 0.5
+                on_release: root.toggle_theme_style()
+
+        BoxLayout:
             size_hint_y: None
             height: dp(48)
             spacing: dp(10)

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -1,0 +1,14 @@
+#:import dp kivy.metrics.dp
+<MatchRegisterScreen>:
+    MDBoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(20)
+
+        MDLabel:
+            text: '[試合データ登録画面]'
+            halign: 'center'
+
+        MDRaisedButton:
+            text: '戻る'
+            on_release: root.change_screen('menu')

--- a/resource/theme/gui/MenuScreen.kv
+++ b/resource/theme/gui/MenuScreen.kv
@@ -1,0 +1,30 @@
+#:import dp kivy.metrics.dp
+<MenuScreen>:
+    MDBoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(20)
+
+        MDLabel:
+            text: 'デッキ分析ツール メインメニュー'
+            halign: 'center'
+            font_style: 'H5'
+
+        MDRaisedButton:
+            text: 'カード情報取得'
+            on_release: root.change_screen('card_info')
+        MDRaisedButton:
+            text: 'デッキ管理'
+            on_release: root.change_screen('deck')
+        MDRaisedButton:
+            text: '試合データ登録'
+            on_release: root.change_screen('match')
+        MDRaisedButton:
+            text: '統計表示'
+            on_release: root.change_screen('stats')
+        MDRaisedButton:
+            text: '設定'
+            on_release: root.change_screen('config')
+        MDRaisedButton:
+            text: '終了'
+            on_release: root.exit_app(self)

--- a/resource/theme/gui/StatsScreen.kv
+++ b/resource/theme/gui/StatsScreen.kv
@@ -1,0 +1,14 @@
+#:import dp kivy.metrics.dp
+<StatsScreen>:
+    MDBoxLayout:
+        orientation: 'vertical'
+        spacing: dp(10)
+        padding: dp(20)
+
+        MDLabel:
+            text: '[統計表示画面]'
+            halign: 'center'
+
+        MDRaisedButton:
+            text: '戻る'
+            on_release: root.change_screen('menu')


### PR DESCRIPTION
## Summary
- read theme style from config and expose in settings
- allow toggling light/dark theme in ConfigScreen
- load theme palette and style on startup
- move Menu, MatchRegister, Stats, and CardList screens to KV files
- document configurable theme settings in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e605034f08333b1259b06e771e695