### PR TITLE
Improve logging and Selenium efficiency

### DIFF
--- a/function/clas/card_detail_screen.py
+++ b/function/clas/card_detail_screen.py
@@ -3,6 +3,11 @@ from kivymd.uix.chip import MDChip
 from function.core.db_handler import DBHandler
 from function.core.effect_dsl_generator import generate_effect_yaml
 import os
+import logging
+from function.core.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 
 class CardDetailScreen(MDScreen):
@@ -35,8 +40,8 @@ class CardDetailScreen(MDScreen):
             h = int(self.ids.hand_score.text)
             g = int(self.ids.grave_score.text)
             self.db.set_card_scores(self.card_name, field=f, hand=h, grave=g)
-        except ValueError:
-            pass
+        except ValueError as e:
+            logger.error(f"Invalid score value: {e}")
         self.manager.current = "card_list"
 
     def open_effect_editor(self):
@@ -53,8 +58,8 @@ class CardDetailScreen(MDScreen):
             yaml_text = generate_effect_yaml(cid, self.card_name, text)
             with open(path, "w", encoding="utf-8") as f:
                 f.write(yaml_text)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.exception(f"Failed to create effect YAML: {e}")
 
         edit_screen = self.manager.get_screen("card_effect_edit")
         edit_screen.load_yaml(cid)

--- a/function/clas/card_get_screen.py
+++ b/function/clas/card_get_screen.py
@@ -26,11 +26,14 @@ class CardInfoScreen(MDScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.db_handler = DBHandler()
-        self.downloader = CardImgDownload(db_handler=self.db_handler)
+        self.downloader = CardImgDownload(db_handler=self.db_handler, persist=True)
         self.dialog = None
         self._is_downloading = False
         self.mode = "keyword"
         self._tab_map = {}  # タイトル名→インスタンスのマッピング
+
+    def on_leave(self, *args):
+        self.downloader.close_driver()
 
     def on_tab_switch(self, instance_tabs, instance_tab, instance_tab_label, tab_text):
         self.mode = "keyword" if tab_text == "カード名を入力" else "deck"

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -5,8 +5,15 @@ from kivy.properties import ObjectProperty
 from kivymd.app import MDApp
 from function.core.config_handler import ConfigHandler, DEFAULT_CONFIG, DEFAULT_FONT_PATH
 from kivymd.uix.filemanager import MDFileManager
+from kivymd.uix.dialog import MDDialog
+from kivy.clock import Clock
 import os
 import shutil
+import logging
+from function.core.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 Builder.load_file("resource/theme/gui/ConfigScreen.kv")
 
@@ -86,9 +93,15 @@ class ConfigScreen(MDScreen):
             shutil.copy(path, dest_path)
             self.ids.font_path_label.text = dest_path
             self.ids.use_custom_font.active = True
-        except Exception:
-            pass
+        except Exception as e:
+            logger.exception(f"Font copy failed: {e}")
+            self._show_dialog("エラー", "フォントファイルのコピーに失敗しました。")
         self.close_file_manager()
+
+    def _show_dialog(self, title: str, text: str) -> None:
+        Clock.schedule_once(
+            lambda dt: MDDialog(title=title, text=text, size_hint=(0.8, 0.4)).open()
+        )
 
     def go_back(self):
         self.manager.current = "menu"

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -1,7 +1,12 @@
 import json
 import os
 import shutil
+import logging
 from typing import Any, Dict
+from function.core.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 DEFAULT_FONT_PATH = r"C:\\Windows\\Fonts\\msgothic.ttc"
 
@@ -40,15 +45,18 @@ class ConfigHandler:
                     data = json.load(f)
                 if isinstance(data, dict):
                     self.config.update(data)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.exception(f"Failed to load config: {e}")
         else:
             self.save()
 
     def save(self) -> None:
         os.makedirs(os.path.dirname(self.path), exist_ok=True)
-        with open(self.path, "w", encoding="utf-8") as f:
-            json.dump(self.config, f, ensure_ascii=False, indent=2)
+        try:
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(self.config, f, ensure_ascii=False, indent=2)
+        except Exception as e:
+            logger.exception(f"Failed to save config: {e}")
 
     def reset(self) -> None:
         self.config = DEFAULT_CONFIG.copy()


### PR DESCRIPTION
## Summary
- log configuration load/save issues in `ConfigHandler`
- show file copy errors in `ConfigScreen`
- log errors in `CardDetailScreen`
- allow `CardImgDownload` to reuse a persistent Selenium driver
- close Selenium driver when leaving `CardInfoScreen`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687eaa8add8883338ea6f147c4ad08a3