### PR TITLE
Enable runtime font switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ pip install kivy kivymd pillow beautifulsoup4 selenium matplotlib
 1. Clone this repository.
 2. Ensure the `external_resource` directory exists (ignored by git). It will be created automatically on first run and stores the SQLite database, logs and other exported data.
 3. Default configuration is stored in `resource/json/config.json`. On first launch this file is copied to `external_resource/config/config.json` if it does not already exist. You can edit the copied file to change the KivyMD color palette and theme style used by the application.
-   The application uses the Windows standard Japanese font `C:\Windows\Fonts\msgothic.ttc` by default. Enable the custom font option in the settings screen if you wish to upload another font file.
+   The application uses the Windows standard Japanese font `C:\Windows\Fonts\msgothic.ttc` by default. Enable the custom font option in the settings screen if you wish to upload another font file.\
+   Changing the font from the settings screen immediately updates all screens without restarting the app.
 
 ## Running the Application
 

--- a/function/clas/card_list_screen.py
+++ b/function/clas/card_list_screen.py
@@ -5,7 +5,7 @@ from kivymd.uix.button import MDIconButton
 from kivymd.uix.card import MDCard
 from kivy.metrics import dp
 from function.core.db_handler import DBHandler
-from kivy.core.text import DEFAULT_FONT
+from kivymd.app import MDApp
 from kivy.utils import get_color_from_hex
 
 class CardListScreen(MDScreen):
@@ -23,7 +23,8 @@ class CardListScreen(MDScreen):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
 
             row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(50))
-            label = MDLabel(text=f"{card_name} x{count}", halign="left", font_name=DEFAULT_FONT)
+            app = MDApp.get_running_app()
+            label = MDLabel(text=f"{card_name} x{count}", halign="left", font_name=app.font_name)
 
             minus_btn = MDIconButton(icon="minus", on_press=lambda x, name=card_name: self.change_card_count(name, -1))
             plus_btn = MDIconButton(icon="plus", on_press=lambda x, name=card_name: self.change_card_count(name, 1))
@@ -48,9 +49,10 @@ class CardListScreen(MDScreen):
         self.ids.title_label.text = "全カード一覧"
         self.ids.grid.clear_widgets()
         all_cards = self.db.get_all_card_names()
+        app = MDApp.get_running_app()
         for idx, card_name in enumerate(all_cards):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
-            label = MDLabel(text=card_name, halign="left", font_name=DEFAULT_FONT)
+            label = MDLabel(text=card_name, halign="left", font_name=app.font_name)
             delete_btn = MDIconButton(icon="delete", disabled=True)
             row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(50))
             row.add_widget(label)

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -95,6 +95,9 @@ class ConfigScreen(MDScreen):
         cfg["theme_color"] = self.ids.theme_color_label.text
         cfg["theme_style"] = self.ids.theme_style_label.text
         self.config_handler.save()
+        app = MDApp.get_running_app()
+        if hasattr(app, "apply_font"):
+            app.apply_font()
 
     def reset_config(self):
         self.config_handler.reset()

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from kivymd.app import MDApp
 from kivymd.uix.screenmanager import MDScreenManager
 from kivymd.uix.screen import MDScreen
-from kivy.core.text import LabelBase, DEFAULT_FONT
+from kivy.core.text import LabelBase
+from kivy.properties import StringProperty
 from kivy.core.window import Window
 from kivy.lang import Builder
 
@@ -22,10 +23,12 @@ from function.clas.card_effect_edit_screen import CardEffectEditScreen
 from function.clas.config_screen import ConfigScreen
 from function.core.config_handler import ConfigHandler, DEFAULT_FONT_PATH
 
+CUSTOM_FONT_NAME = "MgenPlus"
+
 # Load configuration and register font
 config_handler = ConfigHandler()
 font_path = config_handler.config.get("font_path") if config_handler.config.get("use_custom_font") else DEFAULT_FONT_PATH
-LabelBase.register(DEFAULT_FONT, font_path)
+LabelBase.register(CUSTOM_FONT_NAME, font_path)
 
 # CardInfoScreen, DeckManagerScreen の .kv ファイル読み込み
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
@@ -55,9 +58,21 @@ class StatsScreen(MDScreen):
         self.manager.current = screen_name
 
 class DeckAnalyzerApp(MDApp):
+    font_name = StringProperty(CUSTOM_FONT_NAME)
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.config_handler = config_handler
+        self._font_index = 0
+        self.apply_font()
+
+    def apply_font(self):
+        cfg = self.config_handler.config
+        path = cfg.get("font_path") if cfg.get("use_custom_font") else DEFAULT_FONT_PATH
+        self._font_index += 1
+        name = f"{CUSTOM_FONT_NAME}{self._font_index}"
+        LabelBase.register(name, path)
+        self.font_name = name
 
     def build(self):
         cfg = self.config_handler.config

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -23,7 +23,7 @@
             MDLabel:
                 id: card_text
                 text: ''
-                font_name: DEFAULT_FONT
+                font_name: app.font_name
                 size_hint_y: None
                 height: self.texture_size[1]
                 text_size: self.width, None
@@ -34,7 +34,7 @@
             id: card_info
             text: ''
             theme_text_color: 'Secondary'
-            font_name: DEFAULT_FONT
+            font_name: app.font_name
             size_hint_y: None
             height: self.texture_size[1]
             text_size: self.width, None

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -9,7 +9,7 @@
             id: title_label
             text: '[カード一覧]'
             halign: 'center'
-            font_name: DEFAULT_FONT
+            font_name: app.font_name
             size_hint_y: 0.1
 
         MDScrollView:
@@ -30,13 +30,13 @@
             MDTextField:
                 id: name_input
                 hint_text: 'カード名'
-                font_name: DEFAULT_FONT
+                font_name: app.font_name
                 size_hint_x: 0.5
             MDTextField:
                 id: count_input
                 hint_text: '枚数'
                 input_filter: 'int'
-                font_name: DEFAULT_FONT
+                font_name: app.font_name
                 size_hint_x: 0.2
             MDRaisedButton:
                 id: add_button


### PR DESCRIPTION
## Summary
- register custom font name and expose it via `MDApp.font_name`
- let Config screen call `apply_font()` so changes take effect immediately
- update card list screen Python and KV usage to pull `app.font_name`
- update card detail screen KV usage similarly
- document immediate font update in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb2565e70833382c3cb273197bd31