### PR TITLE
Enable dynamic font switching

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,12 +23,8 @@ from function.clas.card_effect_edit_screen import CardEffectEditScreen
 from function.clas.config_screen import ConfigScreen
 from function.core.config_handler import ConfigHandler, DEFAULT_FONT_PATH
 
-CUSTOM_FONT_NAME = "MgenPlus"
-
-# Load configuration and register font
+# Load configuration handler
 config_handler = ConfigHandler()
-font_path = config_handler.config.get("font_path") if config_handler.config.get("use_custom_font") else DEFAULT_FONT_PATH
-LabelBase.register(CUSTOM_FONT_NAME, font_path)
 
 # CardInfoScreen, DeckManagerScreen の .kv ファイル読み込み
 Builder.load_file("resource/theme/gui/CardInfoScreen.kv")
@@ -58,7 +54,7 @@ class StatsScreen(MDScreen):
         self.manager.current = screen_name
 
 class DeckAnalyzerApp(MDApp):
-    font_name = StringProperty(CUSTOM_FONT_NAME)
+    font_name = StringProperty()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -70,7 +66,7 @@ class DeckAnalyzerApp(MDApp):
         cfg = self.config_handler.config
         path = cfg.get("font_path") if cfg.get("use_custom_font") else DEFAULT_FONT_PATH
         self._font_index += 1
-        name = f"{CUSTOM_FONT_NAME}{self._font_index}"
+        name = f"CustomFont{self._font_index}"
         LabelBase.register(name, path)
         self.font_name = name
 

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -9,6 +9,7 @@
             text: ''
             halign: 'center'
             font_style: 'H5'
+            font_name: app.font_name
             size_hint_y: None
             height: dp(40)
 
@@ -48,14 +49,17 @@
                 id: field_score
                 hint_text: 'フィールド'
                 input_filter: 'int'
+                font_name: app.font_name
             MDTextField:
                 id: hand_score
                 hint_text: '手札'
                 input_filter: 'int'
+                font_name: app.font_name
             MDTextField:
                 id: grave_score
                 hint_text: '墓地'
                 input_filter: 'int'
+                font_name: app.font_name
 
         ScrollView:
             size_hint_y: 0.15
@@ -72,13 +76,16 @@
             spacing: 10
             MDRaisedButton:
                 text: '戻る'
+                font_name: app.font_name
                 on_release: root.manager.current = 'card_list'
                 md_bg_color: 0.7, 0.2, 0.2, 1
             MDRaisedButton:
                 text: 'カード効果を設定する'
+                font_name: app.font_name
                 on_release: root.open_effect_editor()
                 md_bg_color: 0.4, 0.4, 0.8, 1
             MDRaisedButton:
                 text: '保存'
+                font_name: app.font_name
                 on_release: root.save_scores()
                 md_bg_color: 0.2, 0.6, 0.2, 1

--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -11,6 +11,7 @@
             halign: 'center'
             size_hint_y: None
             height: dp(40)
+            font_name: app.font_name
 
         MDScrollView:
             MDTextField:
@@ -20,12 +21,14 @@
                 size_hint_y: None
                 height: self.minimum_height
                 mode: 'rectangle'
+                font_name: app.font_name
 
         MDTextField:
             id: file_path_input
             hint_text: 'ファイルパス'
             size_hint_y: None
             height: dp(40)
+            font_name: app.font_name
 
         BoxLayout:
             size_hint_y: None
@@ -33,17 +36,22 @@
             spacing: dp(10)
             MDRaisedButton:
                 text: '読込'
+                font_name: app.font_name
                 on_release: root.reload_yaml()
             MDRaisedButton:
                 text: '保存'
+                font_name: app.font_name
                 on_release: root.save_yaml()
             MDRaisedButton:
                 text: 'インポート'
+                font_name: app.font_name
                 on_release: root.import_yaml()
             MDRaisedButton:
                 text: 'エクスポート'
+                font_name: app.font_name
                 on_release: root.export_yaml()
             MDRaisedButton:
                 text: '戻る'
+                font_name: app.font_name
                 md_bg_color: 0.7,0.2,0.2,1
                 on_release: app.root.current = 'card_detail'

--- a/resource/theme/gui/CardInfoScreen.kv
+++ b/resource/theme/gui/CardInfoScreen.kv
@@ -9,6 +9,7 @@
         size_hint_y: 1
         hint_text: "カード名を入力"
         mode: "rectangle"
+        font_name: app.font_name
     BoxLayout:
         id: card_option_box
         orientation: 'horizontal'
@@ -25,6 +26,7 @@
         size_hint_y: 1
         hint_text: "デッキURLを入力"
         mode: "rectangle"
+        font_name: app.font_name
     BoxLayout:
         id: deck_option_box
         size_hint_y: 1
@@ -36,11 +38,13 @@
         MDLabel:
             size_hint_x: 2
             text: "取得したカードをデッキとして登録する"
+            font_name: app.font_name
         MDTextField:
             id: deck_name_input
             size_hint_x: 2
             hint_text: "デッキ名"
             disabled: True
+            font_name: app.font_name
 
 
 <CardInfoScreen>:
@@ -55,6 +59,7 @@
                 text: "カード情報取得"
                 halign: "center"
                 font_style: "H5"
+                font_name: app.font_name
 
         # タブ（60%）
         MDTabs:
@@ -83,12 +88,14 @@
                     valign: 'center'
                     id: status_label
                     text: "#ステータス表示#"
+                    font_name: app.font_name
 
                 MDLabel:
                     halign: 'center'
                     valign: 'center'
                     id: last_saved_label
                     text: "--"
+                    font_name: app.font_name
             BoxLayout:
                 orientation: 'vertical'
                 size_hint_x: 6
@@ -113,6 +120,7 @@
                 MDRaisedButton:
                     pos_hint:{"center_x": .5, "center_y": .5}
                     text: "戻る"
+                    font_name: app.font_name
                     md_bg_color: 0.9, 0.3, 0.3, 1
                     on_release: root.manager.current = 'menu'
             BoxLayout:
@@ -122,6 +130,7 @@
                 MDRaisedButton:
                     pos_hint:{"center_x": .5, "center_y": .5}
                     text: "取得する"
+                    font_name: app.font_name
                     md_bg_color: 0, 0.6, 0.8, 1
                     on_release: root.on_retrieve_pressed()
                     id: retrieve_button

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -41,6 +41,7 @@
             MDRaisedButton:
                 id: add_button
                 text: '追加'
+                font_name: app.font_name
                 size_hint_x: 0.3
                 md_bg_color: 0.2, 0.6, 0.2, 1
                 on_release: root.add_card_to_deck(self)
@@ -48,6 +49,7 @@
         MDRaisedButton:
             id: back_button
             text: '戻る'
+            font_name: app.font_name
             size_hint_y: 0.1
             md_bg_color: 0.7, 0.2, 0.2, 1
             on_release: root.go_back(self)

--- a/resource/theme/gui/ConfigScreen.kv
+++ b/resource/theme/gui/ConfigScreen.kv
@@ -10,21 +10,25 @@
             halign: 'center'
             size_hint_y: None
             height: dp(40)
+            font_name: app.font_name
 
         MDTextField:
             id: animation_speed
             hint_text: 'アニメーション速度'
             input_filter: 'float'
+            font_name: app.font_name
 
         MDTextField:
             id: max_display_cards
             hint_text: '最大表示カード数'
             input_filter: 'int'
+            font_name: app.font_name
 
         MDTextField:
             id: font_size_base
             hint_text: '使用フォントサイズ'
             input_filter: 'float'
+            font_name: app.font_name
 
         BoxLayout:
             orientation: 'horizontal'
@@ -34,6 +38,7 @@
                 text: 'カスタムフォント'
                 size_hint_x: 0.5
                 valign: 'center'
+                font_name: app.font_name
             MDSwitch:
                 id: use_custom_font
                 size_hint_x: 0.5
@@ -44,10 +49,12 @@
             text: ''
             size_hint_y: None
             height: dp(24)
+            font_name: app.font_name
 
         MDRaisedButton:
             id: font_upload_btn
             text: 'フォントアップロード'
+            font_name: app.font_name
             size_hint_y: None
             height: dp(48)
             disabled: not use_custom_font.active
@@ -62,9 +69,11 @@
                 text: 'Blue'
                 size_hint_x: 0.5
                 valign: 'center'
+                font_name: app.font_name
             MDRaisedButton:
                 id: color_menu_btn
                 text: 'テーマ変更'
+                font_name: app.font_name
                 size_hint_x: 0.5
                 on_release: root.open_color_menu()
 
@@ -77,8 +86,10 @@
                 text: 'Light'
                 size_hint_x: 0.5
                 valign: 'center'
+                font_name: app.font_name
             MDRaisedButton:
                 text: 'スタイル切替'
+                font_name: app.font_name
                 size_hint_x: 0.5
                 on_release: root.toggle_theme_style()
 
@@ -88,10 +99,13 @@
             spacing: dp(10)
             MDRaisedButton:
                 text: '保存'
+                font_name: app.font_name
                 on_release: root.save_config()
             MDRaisedButton:
                 text: 'リセット'
+                font_name: app.font_name
                 on_release: root.reset_config()
             MDRaisedButton:
                 text: '戻る'
+                font_name: app.font_name
                 on_release: root.go_back()

--- a/resource/theme/gui/DeckManagerScreen.kv
+++ b/resource/theme/gui/DeckManagerScreen.kv
@@ -10,6 +10,7 @@
             text: '[デッキ管理]'
             halign: 'center'
             size_hint_y: 0.1
+            font_name: app.font_name
 
         MDBoxLayout:
             id: new_deck_row
@@ -20,8 +21,10 @@
                 id: new_deck_input
                 hint_text: '新しいデッキ名'
                 size_hint_x: 0.7
+                font_name: app.font_name
             MDRaisedButton:
                 text: 'デッキを作成'
+                font_name: app.font_name
                 size_hint_x: 0.2
                 md_bg_color: 0.4, 0.4, 0.6, 1
                 on_press: root.create_deck(self)
@@ -48,8 +51,10 @@
                 id: import_path_input
                 hint_text: 'CSVファイルのパスを入力'
                 size_hint_x: 0.8
+                font_name: app.font_name
             MDRaisedButton:
                 text: 'CSVからインポート'
+                font_name: app.font_name
                 size_hint_x: 0.2
                 md_bg_color: 0.3, 0.6, 0.3, 1
                 on_press: root.import_deck_from_csv(self)
@@ -61,11 +66,13 @@
             size_hint_y: 0.1
             MDRaisedButton:
                 text: '戻る'
+                font_name: app.font_name
                 size_hint_x: 0.5
                 md_bg_color: 0.7, 0.2, 0.2, 1
                 on_press: root.go_back(self)
             MDRaisedButton:
                 text: '全てのカードを見る'
+                font_name: app.font_name
                 size_hint_x: 0.5
                 md_bg_color: 0.2, 0.6, 0.2, 1
                 on_press: root.show_all_cards(self)

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -8,7 +8,9 @@
         MDLabel:
             text: '[試合データ登録画面]'
             halign: 'center'
+            font_name: app.font_name
 
         MDRaisedButton:
             text: '戻る'
+            font_name: app.font_name
             on_release: root.change_screen('menu')

--- a/resource/theme/gui/MenuScreen.kv
+++ b/resource/theme/gui/MenuScreen.kv
@@ -9,22 +9,29 @@
             text: 'デッキ分析ツール メインメニュー'
             halign: 'center'
             font_style: 'H5'
+            font_name: app.font_name
 
         MDRaisedButton:
             text: 'カード情報取得'
+            font_name: app.font_name
             on_release: root.change_screen('card_info')
         MDRaisedButton:
             text: 'デッキ管理'
+            font_name: app.font_name
             on_release: root.change_screen('deck')
         MDRaisedButton:
             text: '試合データ登録'
+            font_name: app.font_name
             on_release: root.change_screen('match')
         MDRaisedButton:
             text: '統計表示'
+            font_name: app.font_name
             on_release: root.change_screen('stats')
         MDRaisedButton:
             text: '設定'
+            font_name: app.font_name
             on_release: root.change_screen('config')
         MDRaisedButton:
             text: '終了'
+            font_name: app.font_name
             on_release: root.exit_app(self)

--- a/resource/theme/gui/StatsScreen.kv
+++ b/resource/theme/gui/StatsScreen.kv
@@ -8,7 +8,9 @@
         MDLabel:
             text: '[統計表示画面]'
             halign: 'center'
+            font_name: app.font_name
 
         MDRaisedButton:
             text: '戻る'
+            font_name: app.font_name
             on_release: root.change_screen('menu')


### PR DESCRIPTION
## Summary
- load config without static font name
- add `font_name` property in `DeckAnalyzerApp`
- register fonts dynamically when applying font
- wire up all `.kv` widgets to use `app.font_name`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687eb697a3d083339357e561a8c9a859