### PR TITLE
Improve Japanese font handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install kivy kivymd pillow beautifulsoup4 selenium matplotlib
 1. Clone this repository.
 2. Ensure the `external_resource` directory exists (ignored by git). It will be created automatically on first run and stores the SQLite database, logs and other exported data.
 3. Default configuration is stored in `resource/json/config.json`. On first launch this file is copied to `external_resource/config/config.json` if it does not already exist. You can edit the copied file to change the KivyMD color palette and theme style used by the application.
-   The application uses the Windows standard Japanese font `C:\Windows\Fonts\msgothic.ttc` by default. Enable the custom font option in the settings screen if you wish to upload another font file.\
+   The application will automatically choose a Japanese capable font such as `Noto Sans JP` or the Windows standard `msgothic.ttc` if available. Enable the custom font option in the settings screen if you wish to upload another font file. The selected file is checked to ensure it contains Japanese characters.\
    Changing the font from the settings screen immediately updates all screens without restarting the app.
 
 ## Running the Application

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -4,6 +4,7 @@ from kivy.lang import Builder
 from kivy.properties import ObjectProperty
 from kivymd.app import MDApp
 from function.core.config_handler import ConfigHandler, DEFAULT_CONFIG
+from function.core.font_utils import font_contains_japanese
 from kivymd.uix.filemanager import MDFileManager
 from kivymd.uix.dialog import MDDialog
 from kivy.clock import Clock
@@ -129,9 +130,15 @@ class ConfigScreen(MDScreen):
         os.makedirs(dest_dir, exist_ok=True)
         dest_path = os.path.join(dest_dir, os.path.basename(path))
         try:
+            if not font_contains_japanese(path):
+                self._show_dialog("警告", "日本語グリフを含まないフォントです。")
+                return
             shutil.copy(path, dest_path)
             self.ids.font_path_label.text = dest_path
             self.ids.use_custom_font.active = True
+            app = MDApp.get_running_app()
+            if hasattr(app, "apply_font"):
+                app.apply_font()
         except Exception as e:
             logger.exception(f"Font copy failed: {e}")
             self._show_dialog("エラー", "フォントファイルのコピーに失敗しました。")

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -4,11 +4,12 @@ import shutil
 import logging
 from typing import Any, Dict
 from function.core.logging_config import setup_logging
+from function.core.font_utils import find_default_font
 
 setup_logging()
 logger = logging.getLogger(__name__)
 
-DEFAULT_FONT_PATH = r"C:\\Windows\\Fonts\\msgothic.ttc"
+DEFAULT_FONT_PATH = find_default_font()
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "animation_speed": 1.0,

--- a/function/core/font_utils.py
+++ b/function/core/font_utils.py
@@ -1,0 +1,35 @@
+import os
+import logging
+from PIL import ImageFont
+from function.core.logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
+# Candidate default fonts that contain Japanese glyphs
+DEFAULT_FONT_CANDIDATES = [
+    r"C:\\Windows\\Fonts\\msgothic.ttc",
+    "/usr/share/fonts/truetype/mgenplus/mgenplus-1m-regular.ttf",
+    "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/truetype/fonts-japanese-gothic.ttf",
+]
+
+def find_default_font() -> str:
+    """Return the first existing default font path."""
+    for path in DEFAULT_FONT_CANDIDATES:
+        if os.path.exists(path):
+            return path
+    return ""
+
+def font_contains_japanese(path: str) -> bool:
+    """Check whether the given font file contains basic Japanese characters."""
+    try:
+        font = ImageFont.truetype(path, 40)
+        for ch in "あいうえお":
+            if font.getmask(ch).getbbox() is None:
+                return False
+        return True
+    except Exception as e:
+        logger.exception(f"font_contains_japanese failed: {e}")
+        return False

--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ from function.clas.card_detail_screen import CardDetailScreen
 from function.clas.card_effect_edit_screen import CardEffectEditScreen
 from function.clas.config_screen import ConfigScreen
 from function.core.config_handler import ConfigHandler, DEFAULT_FONT_PATH
+from function.core.font_utils import font_contains_japanese
 
 # Load configuration handler
 config_handler = ConfigHandler()
@@ -89,7 +90,14 @@ class DeckAnalyzerApp(MDApp):
 
     def apply_font(self):
         cfg = self.config_handler.config
-        path = cfg.get("font_path") if cfg.get("use_custom_font") else DEFAULT_FONT_PATH
+        path = DEFAULT_FONT_PATH
+        if cfg.get("use_custom_font"):
+            custom = cfg.get("font_path")
+            if custom and os.path.exists(custom) and font_contains_japanese(custom):
+                path = custom
+        if not os.path.exists(path):
+            logger.warning(f"Font path not found: {path}")
+            return
         self._font_index += 1
         name = f"CustomFont{self._font_index}"
         LabelBase.register(name, path)


### PR DESCRIPTION
## Summary
- add utility to find fonts with Japanese glyphs
- use fallback fonts in config handler
- check custom fonts and update at runtime
- document auto font selection in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f8908f83083338dcaf2075f903d8b