### PR TITLE
Remove font update path operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install kivy kivymd pillow beautifulsoup4 selenium matplotlib
 
 1. Clone this repository.
 2. Ensure the `external_resource` directory exists (ignored by git). It will be created automatically on first run and stores the SQLite database, logs and other exported data.
-3. Default configuration is stored in `resource/json/config.json`. On first launch this file is copied to `external_resource/config/config.json` if it does not already exist. You can edit the copied file to change the KivyMD color palette and theme style used by the application. The application now uses the bundled **Mgen+ 1c** font internally and does not allow uploading custom fonts.
+3. Default configuration is stored in `resource/json/config.json`. On first launch this file is copied to `external_resource/config/config.json` if it does not already exist. You can edit the copied file to change the KivyMD color palette and theme style used by the application.
 
 ## Running the Application
 

--- a/function/clas/card_list_screen.py
+++ b/function/clas/card_list_screen.py
@@ -23,8 +23,7 @@ class CardListScreen(MDScreen):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
 
             row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(50))
-            app = MDApp.get_running_app()
-            label = MDLabel(text=f"{card_name} x{count}", halign="left", font_name=app.font_name)
+            label = MDLabel(text=f"{card_name} x{count}", halign="left")
 
             minus_btn = MDIconButton(icon="minus", on_press=lambda x, name=card_name: self.change_card_count(name, -1))
             plus_btn = MDIconButton(icon="plus", on_press=lambda x, name=card_name: self.change_card_count(name, 1))
@@ -49,10 +48,9 @@ class CardListScreen(MDScreen):
         self.ids.title_label.text = "全カード一覧"
         self.ids.grid.clear_widgets()
         all_cards = self.db.get_all_card_names()
-        app = MDApp.get_running_app()
         for idx, card_name in enumerate(all_cards):
             bg_color = get_color_from_hex("#f5f5f5") if idx % 2 == 0 else get_color_from_hex("#ffffff")
-            label = MDLabel(text=card_name, halign="left", font_name=app.font_name)
+            label = MDLabel(text=card_name, halign="left")
             delete_btn = MDIconButton(icon="delete", disabled=True)
             row = MDBoxLayout(orientation="horizontal", spacing=10, size_hint_y=None, height=dp(50))
             row.add_widget(label)

--- a/function/clas/config_screen.py
+++ b/function/clas/config_screen.py
@@ -83,9 +83,6 @@ class ConfigScreen(MDScreen):
         cfg["theme_color"] = self.ids.theme_color_label.text
         cfg["theme_style"] = self.ids.theme_style_label.text
         self.config_handler.save()
-        app = MDApp.get_running_app()
-        if hasattr(app, "apply_font"):
-            app.apply_font()
 
     def reset_config(self):
         self.config_handler.reset()

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -9,9 +9,6 @@ from function.core.logging_config import setup_logging
 setup_logging()
 logger = logging.getLogger(__name__)
 
-DEFAULT_FONT_PATH = os.path.join(
-    "resource", "theme", "font", "mgenplus-1c-regular.ttf"
-)
 
 DEFAULT_CONFIG: Dict[str, Any] = {
     "animation_speed": 1.0,

--- a/main.py
+++ b/main.py
@@ -1,25 +1,17 @@
 from kivymd.app import MDApp
 from kivymd.uix.screenmanager import MDScreenManager
 from kivymd.uix.screen import MDScreen
-from kivy.core.text import LabelBase
-from kivy.properties import StringProperty
 from kivy.core.window import Window
 from kivy.lang import Builder
 from kivy.uix.scrollview import ScrollView
 from kivymd.uix.label import MDLabel
 from kivymd.uix.dialog import MDDialog
+from kivy.properties import StringProperty
 
 import logging
 import os
 from function.core.logging_config import setup_logging
 from app_version import get_version_info
-
-DEFAULT_FONT_PATH = os.path.join(
-    "resource",
-    "theme",
-    "font",
-    "mgenplus-1c-regular.ttf",
-)
 
 # Ensure external_resource directory exists and initialize logging
 os.makedirs("external_resource", exist_ok=True)
@@ -86,23 +78,10 @@ class StatsScreen(MDScreen):
         self.manager.current = screen_name
 
 class DeckAnalyzerApp(MDApp):
-    font_name = StringProperty()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.config_handler = config_handler
-        self._font_index = 0
-        self.apply_font()
-
-    def apply_font(self):
-        path = DEFAULT_FONT_PATH
-        if not os.path.exists(path):
-            logger.warning(f"Font path not found: {path}")
-            return
-        self._font_index += 1
-        name = f"CustomFont{self._font_index}"
-        LabelBase.register(name, path)
-        self.font_name = name
 
     def build(self):
         cfg = self.config_handler.config


### PR DESCRIPTION
## Summary
- strip dynamic font handling from `main.py`
- drop `apply_font` usage in `ConfigScreen`
- remove font references from `CardListScreen`
- delete unused font path constant
- update README accordingly

## Testing
- `python -m py_compile main.py function/clas/card_list_screen.py function/clas/config_screen.py function/core/config_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_6880eaa7f0788333a667679c41b99d6f