### PR TITLE
Use theme colors for chips and buttons

### DIFF
--- a/function/clas/card_detail_screen.py
+++ b/function/clas/card_detail_screen.py
@@ -1,5 +1,6 @@
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.chip import MDChip
+from kivymd.app import MDApp
 from function.core.db_handler import DBHandler
 from function.core.effect_dsl_generator import generate_effect_yaml
 import os
@@ -32,6 +33,9 @@ class CardDetailScreen(MDScreen):
         usage_box.clear_widgets()
         for deck, count in self.db.get_deck_usage_for_card(card_name):
             chip = MDChip(text=f"{deck} x{count}")
+            app = MDApp.get_running_app()
+            chip.text_color = app.theme_cls.text_color
+            chip.md_bg_color = app.theme_cls.accent_color
             usage_box.add_widget(chip)
 
     def save_scores(self):

--- a/function/clas/match_register_screen.py
+++ b/function/clas/match_register_screen.py
@@ -1,6 +1,7 @@
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.chip import MDChip
+from kivymd.app import MDApp
 from kivymd.uix.dialog import MDDialog
 from function.core.db_handler import DBHandler
 
@@ -50,6 +51,9 @@ class MatchRegisterScreen(MDScreen):
 
         for tag in self.db.get_all_tags():
             chip = MDChip(text=tag)
+            app = MDApp.get_running_app()
+            chip.text_color = app.theme_cls.text_color
+            chip.md_bg_color = app.theme_cls.accent_color
             chip.state = "normal"
             chip.bind(on_release=self._on_chip_toggle)
             self.ids.tag_box.add_widget(chip)
@@ -60,6 +64,9 @@ class MatchRegisterScreen(MDScreen):
         if tag:
             self.db.add_tag(tag)
             chip = MDChip(text=tag)
+            app = MDApp.get_running_app()
+            chip.text_color = app.theme_cls.text_color
+            chip.md_bg_color = app.theme_cls.accent_color
             chip.state = "normal"
             chip.bind(on_release=self._on_chip_toggle)
             self.ids.tag_box.add_widget(chip)

--- a/function/core/config_handler.py
+++ b/function/core/config_handler.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "font_size_base": 16,
     "theme_color": "Blue",
     "theme_style": "Light",
+    "accent_color": "Amber",
 }
 
 DEFAULT_CONFIG_PATH = os.path.join("resource", "json", "config.json")

--- a/main.py
+++ b/main.py
@@ -89,6 +89,7 @@ class DeckAnalyzerApp(MDApp):
         cfg = self.config_handler.config
         self.theme_cls.primary_palette = cfg.get("theme_color", "Blue")
         self.theme_cls.theme_style = cfg.get("theme_style", "Light")
+        self.theme_cls.accent_palette = cfg.get("accent_color", "Amber")
         sm = MDScreenManager()
         sm.add_widget(MenuScreen(name="menu"))
         sm.add_widget(CardInfoScreen(name="card_info"))  # ← 追加

--- a/resource/json/config.json
+++ b/resource/json/config.json
@@ -3,5 +3,6 @@
   "max_display_cards": 50,
   "font_size_base": 16,
   "theme_color": "Blue",
-  "theme_style": "Light"
+  "theme_style": "Light",
+  "accent_color": "Amber"
 }

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -71,12 +71,12 @@
             MDRaisedButton:
                 text: '戻る'
                 on_release: root.manager.current = 'card_list'
-                md_bg_color: 0.7, 0.2, 0.2, 1
+                md_bg_color: app.theme_cls.accent_color
             MDRaisedButton:
                 text: 'カード効果を設定する'
                 on_release: root.open_effect_editor()
-                md_bg_color: 0.4, 0.4, 0.8, 1
+                md_bg_color: app.theme_cls.primary_light
             MDRaisedButton:
                 text: '保存'
                 on_release: root.save_scores()
-                md_bg_color: 0.2, 0.6, 0.2, 1
+                md_bg_color: app.theme_cls.primary_color

--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -45,5 +45,5 @@
                 on_release: root.export_yaml()
             MDRaisedButton:
                 text: '戻る'
-                md_bg_color: 0.7,0.2,0.2,1
+                md_bg_color: app.theme_cls.accent_color
                 on_release: app.root.current = 'card_detail'

--- a/resource/theme/gui/CardInfoScreen.kv
+++ b/resource/theme/gui/CardInfoScreen.kv
@@ -113,7 +113,7 @@
                 MDRaisedButton:
                     pos_hint:{"center_x": .5, "center_y": .5}
                     text: "戻る"
-                    md_bg_color: 0.9, 0.3, 0.3, 1
+                    md_bg_color: app.theme_cls.accent_color
                     on_release: root.manager.current = 'menu'
             BoxLayout:
                 size_hint_x: 4
@@ -122,7 +122,7 @@
                 MDRaisedButton:
                     pos_hint:{"center_x": .5, "center_y": .5}
                     text: "取得する"
-                    md_bg_color: 0, 0.6, 0.8, 1
+                    md_bg_color: app.theme_cls.primary_color
                     on_release: root.on_retrieve_pressed()
                     id: retrieve_button
             BoxLayout:

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -39,12 +39,12 @@
                 id: add_button
                 text: '追加'
                 size_hint_x: 0.3
-                md_bg_color: 0.2, 0.6, 0.2, 1
+                md_bg_color: app.theme_cls.primary_color
                 on_release: root.add_card_to_deck(self)
 
         MDRaisedButton:
             id: back_button
             text: '戻る'
             size_hint_y: 0.1
-            md_bg_color: 0.7, 0.2, 0.2, 1
+            md_bg_color: app.theme_cls.accent_color
             on_release: root.go_back(self)

--- a/resource/theme/gui/DeckManagerScreen.kv
+++ b/resource/theme/gui/DeckManagerScreen.kv
@@ -23,7 +23,7 @@
             MDRaisedButton:
                 text: 'デッキを作成'
                 size_hint_x: 0.2
-                md_bg_color: 0.4, 0.4, 0.6, 1
+                md_bg_color: app.theme_cls.primary_color
                 on_press: root.create_deck(self)
             MDIconButton:
                 icon: 'refresh'
@@ -51,7 +51,7 @@
             MDRaisedButton:
                 text: 'CSVからインポート'
                 size_hint_x: 0.2
-                md_bg_color: 0.3, 0.6, 0.3, 1
+                md_bg_color: app.theme_cls.primary_color
                 on_press: root.import_deck_from_csv(self)
 
         MDBoxLayout:
@@ -62,10 +62,10 @@
             MDRaisedButton:
                 text: '戻る'
                 size_hint_x: 0.5
-                md_bg_color: 0.7, 0.2, 0.2, 1
+                md_bg_color: app.theme_cls.accent_color
                 on_press: root.go_back(self)
             MDRaisedButton:
                 text: '全てのカードを見る'
                 size_hint_x: 0.5
-                md_bg_color: 0.2, 0.6, 0.2, 1
+                md_bg_color: app.theme_cls.primary_color
                 on_press: root.show_all_cards(self)

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -90,11 +90,11 @@
             MDRaisedButton:
                 text: '登録'
                 size_hint_x: 0.5
-                md_bg_color: 0.2, 0.6, 0.2, 1
+                md_bg_color: app.theme_cls.primary_color
                 on_release: root.register_match()
             MDRaisedButton:
                 text: '戻る'
                 size_hint_x: 0.5
-                md_bg_color: 0.7, 0.2, 0.2, 1
+                md_bg_color: app.theme_cls.accent_color
                 on_press: root.go_back(self)
 


### PR DESCRIPTION
## Summary
- add accent color to default config
- set accent palette during app build
- style `MDChip` widgets with theme colors
- replace fixed button colors with `theme_cls` values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884ac8f2c008333b26c4cd35abc52b4