### PR TITLE
Improve tag selection UI

### DIFF
--- a/function/clas/match_register_screen.py
+++ b/function/clas/match_register_screen.py
@@ -12,6 +12,7 @@ class MatchRegisterScreen(MDScreen):
         self.db = DBHandler()
         self.deck_menu = None
         self.tag_chips = []
+        self.selected_tags = set()
         self.dialog = None
 
     def on_pre_enter(self, *args):
@@ -48,6 +49,8 @@ class MatchRegisterScreen(MDScreen):
     def _load_tags(self):
         self.ids.tag_box.clear_widgets()
         self.tag_chips = []
+        self.selected_tags = set()
+        self.ids.opponent_tag_field.text = ""
 
         for tag in self.db.get_all_tags():
             chip = MDChip(text=tag)
@@ -77,9 +80,12 @@ class MatchRegisterScreen(MDScreen):
         if chip.state == "down":
             chip.state = "normal"
             chip.icon = ""
+            self.selected_tags.discard(chip.text)
         else:
             chip.state = "down"
             chip.icon = "check"
+            self.selected_tags.add(chip.text)
+        self.ids.opponent_tag_field.text = ",".join(sorted(self.selected_tags))
 
     def on_win_checkbox(self, instance, value):
         if value:
@@ -100,7 +106,7 @@ class MatchRegisterScreen(MDScreen):
         if not result:
             self._show_dialog("エラー", "勝敗を選択してください")
             return
-        tags = [chip.text for chip in self.tag_chips if chip.state == "down"]
+        tags = list(self.selected_tags)
         note = self.ids.note_field.text.strip()
         self.db.add_match_result(deck, tags, result, note)
         self._show_dialog("登録完了", "試合結果を登録しました")
@@ -108,6 +114,8 @@ class MatchRegisterScreen(MDScreen):
         for chip in self.tag_chips:
             chip.state = "normal"
             chip.icon = ""
+        self.selected_tags.clear()
+        self.ids.opponent_tag_field.text = ""
         self.ids.win_cb.active = False
         self.ids.lose_cb.active = False
 

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -29,15 +29,26 @@
             size_hint_y: None
             height: dp(24)
 
+        MDTextField:
+            id: opponent_tag_field
+            hint_text: '選択タグ'
+            readonly: True
+            size_hint_y: None
+            height: dp(48)
+
         ScrollView:
             size_hint_y: None
             height: dp(80)
+            do_scroll_x: True
+            do_scroll_y: False
             MDBoxLayout:
                 id: tag_box
                 orientation: 'horizontal'
                 size_hint_y: None
                 height: self.minimum_height
                 adaptive_height: True
+                size_hint_x: None
+                width: self.minimum_width
                 spacing: dp(4)
 
         MDBoxLayout:


### PR DESCRIPTION
## Summary
- update MatchRegisterScreen logic to track selected tags
- add readonly field showing selected tags
- keep tag selections synced when registering matches

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6884b7963234833386e1f3c0a89eb72f