### PR TITLE
Add AppBar titles to screens

### DIFF
--- a/function/clas/card_detail_screen.py
+++ b/function/clas/card_detail_screen.py
@@ -20,7 +20,7 @@ class CardDetailScreen(MDScreen):
     def load_card(self, card_name):
         self.card_name = card_name
         info = self.db.get_full_card_info(card_name) or {}
-        self.ids.name_label.text = card_name
+        self.ids.app_bar.title = card_name
         self.ids.field_score.text = str(info.get("field_score", 0))
         self.ids.hand_score.text = str(info.get("hand_score", 0))
         self.ids.grave_score.text = str(info.get("grave_score", 0))

--- a/function/clas/card_list_screen.py
+++ b/function/clas/card_list_screen.py
@@ -31,7 +31,7 @@ class CardListScreen(MDScreen):
 
     def load_deck(self, deck_name):
         self.current_deck_name = deck_name
-        self.ids.title_label.text = f"デッキ: {deck_name} のカード一覧"
+        self.ids.app_bar.title = f"デッキ: {deck_name} のカード一覧"
         self.ids.grid.clear_widgets()
         cards = self.db.get_cards_by_deck(deck_name)
         for idx, (card_name, count) in enumerate(cards):
@@ -62,7 +62,7 @@ class CardListScreen(MDScreen):
 
     def load_all_cards(self):
         self.current_deck_name = None
-        self.ids.title_label.text = "全カード一覧"
+        self.ids.app_bar.title = "全カード一覧"
         self.ids.grid.clear_widgets()
         all_cards = self.db.get_all_card_names()
         for idx, card_name in enumerate(all_cards):

--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -4,13 +4,9 @@
         spacing: 10
         padding: 10
 
-        MDLabel:
-            id: name_label
-            text: ''
-            halign: 'center'
-            font_style: 'H5'
-            size_hint_y: None
-            height: dp(40)
+        MDTopAppBar:
+            id: app_bar
+            title: ''
 
         Image:
             id: card_image

--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -5,12 +5,9 @@
         spacing: dp(10)
         padding: dp(10)
 
-        MDLabel:
-            id: title_label
-            text: 'カード効果編集'
-            halign: 'center'
-            size_hint_y: None
-            height: dp(40)
+        MDTopAppBar:
+            id: app_bar
+            title: 'カード効果編集'
 
         MDScrollView:
             MDTextField:

--- a/resource/theme/gui/CardInfoScreen.kv
+++ b/resource/theme/gui/CardInfoScreen.kv
@@ -48,13 +48,9 @@
         orientation: 'vertical'
 
         # タイトル領域（15%）
-        BoxLayout:
-            size_hint_y: 1.5
-            padding: 10
-            MDLabel:
-                text: "カード情報取得"
-                halign: "center"
-                font_style: "H5"
+        MDTopAppBar:
+            id: app_bar
+            title: "カード情報取得"
 
         # タブ（60%）
         MDTabs:

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -5,11 +5,9 @@
         spacing: dp(10)
         padding: dp(10)
 
-        MDLabel:
-            id: title_label
-            text: '[カード一覧]'
-            halign: 'center'
-            size_hint_y: 0.1
+        MDTopAppBar:
+            id: app_bar
+            title: '[カード一覧]'
 
         MDScrollView:
             id: scroll

--- a/resource/theme/gui/ConfigScreen.kv
+++ b/resource/theme/gui/ConfigScreen.kv
@@ -5,11 +5,9 @@
         spacing: dp(10)
         padding: dp(10)
 
-        MDLabel:
-            text: '設定'
-            halign: 'center'
-            size_hint_y: None
-            height: dp(40)
+        MDTopAppBar:
+            id: app_bar
+            title: '設定'
 
         MDTextField:
             id: animation_speed

--- a/resource/theme/gui/DeckManagerScreen.kv
+++ b/resource/theme/gui/DeckManagerScreen.kv
@@ -6,10 +6,9 @@
         spacing: 10
         padding: 10
 
-        MDLabel:
-            text: '[デッキ管理]'
-            halign: 'center'
-            size_hint_y: 0.1
+        MDTopAppBar:
+            id: app_bar
+            title: '[デッキ管理]'
 
         MDBoxLayout:
             id: new_deck_row

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -5,9 +5,9 @@
         spacing: dp(10)
         padding: dp(20)
 
-        MDLabel:
-            text: '[試合結果登録]'
-            halign: 'center'
+        MDTopAppBar:
+            id: app_bar
+            title: '[試合結果登録]'
 
         MDBoxLayout:
             size_hint_y: None

--- a/resource/theme/gui/StatsScreen.kv
+++ b/resource/theme/gui/StatsScreen.kv
@@ -5,9 +5,9 @@
         spacing: dp(10)
         padding: dp(20)
 
-        MDLabel:
-            text: '[統計表示画面]'
-            halign: 'center'
+        MDTopAppBar:
+            id: app_bar
+            title: '[統計表示画面]'
 
         MDRaisedButton:
             text: '戻る'


### PR DESCRIPTION
## Summary
- display screen titles in `MDTopAppBar` widgets
- update `card_list_screen.py` and `card_detail_screen.py` for new title IDs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884bb89e03483339a6a7f1b08cb00df