### PR TITLE
Use BottomAppBar on non-menu screens

### DIFF
--- a/resource/theme/gui/CardDetailScreen.kv
+++ b/resource/theme/gui/CardDetailScreen.kv
@@ -64,19 +64,8 @@
                 height: self.minimum_height
                 spacing: 5
 
-        MDBoxLayout:
-            size_hint_y: None
-            height: dp(48)
-            spacing: 10
-            MDRaisedButton:
-                text: '戻る'
-                on_release: root.manager.current = 'card_list'
-                md_bg_color: app.theme_cls.accent_color
-            MDRaisedButton:
-                text: 'カード効果を設定する'
-                on_release: root.open_effect_editor()
-                md_bg_color: app.theme_cls.primary_light
-            MDRaisedButton:
-                text: '保存'
-                on_release: root.save_scores()
-                md_bg_color: app.theme_cls.primary_color
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: setattr(root.manager, 'current', 'card_list')]]
+                right_action_items: [["cog", lambda x: root.open_effect_editor()], ["content-save", lambda x: root.save_scores()]]

--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -27,23 +27,12 @@
             size_hint_y: None
             height: dp(40)
 
-        BoxLayout:
-            size_hint_y: None
-            height: dp(48)
-            spacing: dp(10)
-            MDRaisedButton:
-                text: '読込'
-                on_release: root.reload_yaml()
-            MDRaisedButton:
-                text: '保存'
-                on_release: root.save_yaml()
-            MDRaisedButton:
-                text: 'インポート'
-                on_release: root.import_yaml()
-            MDRaisedButton:
-                text: 'エクスポート'
-                on_release: root.export_yaml()
-            MDRaisedButton:
-                text: '戻る'
-                md_bg_color: app.theme_cls.accent_color
-                on_release: app.root.current = 'card_detail'
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items:
+                    [["arrow-left", lambda x: setattr(app.root, 'current', 'card_detail')],
+                     ["reload", lambda x: root.reload_yaml()],
+                     ["content-save", lambda x: root.save_yaml()],
+                     ["upload", lambda x: root.import_yaml()],
+                     ["download", lambda x: root.export_yaml()]]

--- a/resource/theme/gui/CardInfoScreen.kv
+++ b/resource/theme/gui/CardInfoScreen.kv
@@ -102,31 +102,9 @@
                 orientation: 'vertical'
                 size_hint_x: 2
 
-        # ボタン領域（15%）
-        BoxLayout:
-            orientation: 'horizontal'
-            size_hint_y: 1
-            BoxLayout:
-                size_hint_x: 2
-            BoxLayout:
-                size_hint_x: 1
-                MDRaisedButton:
-                    pos_hint:{"center_x": .5, "center_y": .5}
-                    text: "戻る"
-                    md_bg_color: app.theme_cls.accent_color
-                    on_release: root.manager.current = 'menu'
-            BoxLayout:
-                size_hint_x: 4
-            BoxLayout:
-                size_hint_x: 1
-                MDRaisedButton:
-                    pos_hint:{"center_x": .5, "center_y": .5}
-                    text: "取得する"
-                    md_bg_color: app.theme_cls.primary_color
-                    on_release: root.on_retrieve_pressed()
-                    id: retrieve_button
-            BoxLayout:
-                size_hint_x: 2
-        BoxLayout:
-            orientation: 'horizontal'
-            size_hint_y: 0.1
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: setattr(root.manager, 'current', 'menu')]]
+                right_action_items: [["play", lambda x: root.on_retrieve_pressed()]]
+                id: retrieve_button

--- a/resource/theme/gui/CardListScreen.kv
+++ b/resource/theme/gui/CardListScreen.kv
@@ -42,9 +42,7 @@
                 md_bg_color: app.theme_cls.primary_color
                 on_release: root.add_card_to_deck(self)
 
-        MDRaisedButton:
-            id: back_button
-            text: '戻る'
-            size_hint_y: 0.1
-            md_bg_color: app.theme_cls.accent_color
-            on_release: root.go_back(self)
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: root.go_back(x)]]

--- a/resource/theme/gui/ConfigScreen.kv
+++ b/resource/theme/gui/ConfigScreen.kv
@@ -56,16 +56,8 @@
                 size_hint_x: 0.5
                 on_release: root.toggle_theme_style()
 
-        BoxLayout:
-            size_hint_y: None
-            height: dp(48)
-            spacing: dp(10)
-            MDRaisedButton:
-                text: '保存'
-                on_release: root.save_config()
-            MDRaisedButton:
-                text: 'リセット'
-                on_release: root.reset_config()
-            MDRaisedButton:
-                text: '戻る'
-                on_release: root.go_back()
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: root.go_back()]]
+                right_action_items: [["backup-restore", lambda x: root.reset_config()], ["content-save", lambda x: root.save_config()]]

--- a/resource/theme/gui/DeckManagerScreen.kv
+++ b/resource/theme/gui/DeckManagerScreen.kv
@@ -54,18 +54,8 @@
                 md_bg_color: app.theme_cls.primary_color
                 on_press: root.import_deck_from_csv(self)
 
-        MDBoxLayout:
-            id: bottom_row
-            orientation: 'horizontal'
-            spacing: 10
-            size_hint_y: 0.1
-            MDRaisedButton:
-                text: '戻る'
-                size_hint_x: 0.5
-                md_bg_color: app.theme_cls.accent_color
-                on_press: root.go_back(self)
-            MDRaisedButton:
-                text: '全てのカードを見る'
-                size_hint_x: 0.5
-                md_bg_color: app.theme_cls.primary_color
-                on_press: root.show_all_cards(self)
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: root.go_back(x)]]
+                right_action_items: [["format-list-bulleted", lambda x: root.show_all_cards(x)]]

--- a/resource/theme/gui/MatchRegisterScreen.kv
+++ b/resource/theme/gui/MatchRegisterScreen.kv
@@ -94,18 +94,9 @@
             height: dp(100)
             multiline: True
 
-        MDBoxLayout:
-            size_hint_y: None
-            height: dp(48)
-            spacing: dp(10)
-            MDRaisedButton:
-                text: '登録'
-                size_hint_x: 0.5
-                md_bg_color: app.theme_cls.primary_color
-                on_release: root.register_match()
-            MDRaisedButton:
-                text: '戻る'
-                size_hint_x: 0.5
-                md_bg_color: app.theme_cls.accent_color
-                on_press: root.go_back(self)
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: root.go_back(x)]]
+                right_action_items: [["content-save", lambda x: root.register_match()]]
 

--- a/resource/theme/gui/StatsScreen.kv
+++ b/resource/theme/gui/StatsScreen.kv
@@ -9,6 +9,7 @@
             text: '[統計表示画面]'
             halign: 'center'
 
-        MDRaisedButton:
-            text: '戻る'
-            on_release: root.change_screen('menu')
+        MDBottomAppBar:
+            MDToolbar:
+                type: "bottom"
+                left_action_items: [["arrow-left", lambda x: root.change_screen('menu')]]


### PR DESCRIPTION
## Summary
- switch bottom rows on each screen to `MDBottomAppBar`
- show back button on the left and screen specific icons on the right

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6884d43ab6ac8333b6957ecf3af604d7