### PR TITLE
Fix indentation in CardEffectEditScreen kv

### DIFF
--- a/resource/theme/gui/CardEffectEditScreen.kv
+++ b/resource/theme/gui/CardEffectEditScreen.kv
@@ -32,7 +32,7 @@
                 type: "bottom"
                 left_action_items:
                     [["arrow-left", lambda x: setattr(app.root, 'current', 'card_detail')],
-                     ["reload", lambda x: root.reload_yaml()],
-                     ["content-save", lambda x: root.save_yaml()],
-                     ["upload", lambda x: root.import_yaml()],
-                     ["download", lambda x: root.export_yaml()]]
+                    ["reload", lambda x: root.reload_yaml()],
+                    ["content-save", lambda x: root.save_yaml()],
+                    ["upload", lambda x: root.import_yaml()],
+                    ["download", lambda x: root.export_yaml()]]


### PR DESCRIPTION
## Summary
- fix inconsistent indentation in `CardEffectEditScreen.kv`

## Testing
- `python - <<'PY'
import re, glob
bad=[]
for file in glob.glob('resource/theme/gui/*.kv'):
    with open(file) as f:
        for i,line in enumerate(f,1):
            if line.strip()=='' or line.lstrip().startswith('#'): continue
            indent=re.match(r'^\s+',line)
            if indent:
                n=len(indent.group(0).replace('\t','    '))
                if n%4!=0:
                    bad.append((file,i,n))
if bad:
    print('Issues found:')
    print(bad)
else:
    print('No indentation issues found.')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68851e1e0070833390b64687bf0d9064