### PR TITLE
Fix duplicate StringProperty import

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from kivy.lang import Builder
 from kivy.uix.scrollview import ScrollView
 from kivymd.uix.label import MDLabel
 from kivymd.uix.dialog import MDDialog
-from kivy.properties import StringProperty
 
 import logging
 import os


### PR DESCRIPTION
## Summary
- remove redundant StringProperty import from main.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689200bade5c8333997c31c1bbd1fa0c