### PR TITLE
Use context-managed DB connections

### DIFF
--- a/function/clas/deck_manager.py
+++ b/function/clas/deck_manager.py
@@ -10,7 +10,6 @@ import os
 class DeckManagerScreen(MDScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.db = DBHandler()
         self.dialog = None
         self.current_import_deck = None
 
@@ -19,7 +18,8 @@ class DeckManagerScreen(MDScreen):
 
     def refresh_deck_list(self):
         self.ids.deck_buttons_layout.clear_widgets()
-        decks = self.db.get_all_decks()
+        with DBHandler() as db:
+            decks = db.get_all_decks()
         for deck in decks:
             row = MDBoxLayout(orientation="horizontal", spacing=5, size_hint_y=None, height=dp(48))
 
@@ -51,13 +51,15 @@ class DeckManagerScreen(MDScreen):
     def create_deck(self, instance):
         name = self.ids.new_deck_input.text.strip()
         if name:
-            self.db.add_deck(name)
+            with DBHandler() as db:
+                db.add_deck(name)
             self.ids.new_deck_input.text = ""
             self.refresh_deck_list()
             self.show_dialog("デッキを追加しました")
 
     def delete_deck(self, name):
-        self.db.delete_deck(name)
+        with DBHandler() as db:
+            db.delete_deck(name)
         if self.current_import_deck == name:
             self.current_import_deck = None
         self.refresh_deck_list()
@@ -83,7 +85,8 @@ class DeckManagerScreen(MDScreen):
                 for row in reader:
                     if len(row) == 2:
                         name, count = row[0].strip(), int(row[1])
-                        self.db.add_card(self.current_import_deck, name, count)
+                        with DBHandler() as db:
+                            db.add_card(self.current_import_deck, name, count)
             self.show_dialog("CSVからインポートしました")
         except Exception as e:
             self.show_dialog(f"エラー: {e}")

--- a/function/clas/match_register_screen.py
+++ b/function/clas/match_register_screen.py
@@ -9,7 +9,6 @@ from function.core.db_handler import DBHandler
 class MatchRegisterScreen(MDScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.db = DBHandler()
         self.deck_menu = None
         self.tag_chips = []
         self.selected_tags = set()
@@ -20,7 +19,8 @@ class MatchRegisterScreen(MDScreen):
         self._load_tags()
 
     def _load_decks(self):
-        decks = self.db.get_all_decks()
+        with DBHandler() as db:
+            decks = db.get_all_decks()
         menu_items = [
             {
                 "text": name,
@@ -52,7 +52,9 @@ class MatchRegisterScreen(MDScreen):
         self.selected_tags = set()
         self.ids.opponent_tag_field.text = ""
 
-        for tag in self.db.get_all_tags():
+        with DBHandler() as db:
+            tags = db.get_all_tags()
+        for tag in tags:
             chip = MDChip(text=tag)
             app = MDApp.get_running_app()
             chip.text_color = app.theme_cls.text_color
@@ -65,7 +67,8 @@ class MatchRegisterScreen(MDScreen):
     def add_new_tag(self):
         tag = self.ids.new_tag_field.text.strip()
         if tag:
-            self.db.add_tag(tag)
+            with DBHandler() as db:
+                db.add_tag(tag)
             chip = MDChip(text=tag)
             app = MDApp.get_running_app()
             chip.text_color = app.theme_cls.text_color
@@ -108,7 +111,8 @@ class MatchRegisterScreen(MDScreen):
             return
         tags = list(self.selected_tags)
         note = self.ids.note_field.text.strip()
-        self.db.add_match_result(deck, tags, result, note)
+        with DBHandler() as db:
+            db.add_match_result(deck, tags, result, note)
         self._show_dialog("登録完了", "試合結果を登録しました")
         self.ids.note_field.text = ""
         for chip in self.tag_chips:


### PR DESCRIPTION
## Summary
- Add `open`/`close` and context manager support to `DBHandler`
- Update database consumers to open connections with `with DBHandler()` for temporary access
- Adjust card image downloader to manage its own database connections

## Testing
- `pytest`
- `python -m py_compile function/core/db_handler.py function/clas/card_get_screen.py function/clas/card_list_screen.py function/clas/deck_manager.py function/clas/match_register_screen.py function/clas/card_detail_screen.py function/core/card_img_download.py`


------
https://chatgpt.com/codex/tasks/task_e_6892016b8560833390bfb218f12052a8