### PR TITLE
Remove unused time import

### DIFF
--- a/function/clas/card_get_screen.py
+++ b/function/clas/card_get_screen.py
@@ -1,5 +1,5 @@
 import threading
-import time, os
+import os
 import logging
 from function.core.logging_config import setup_logging
 from kivy.clock import Clock


### PR DESCRIPTION
## Summary
- Remove unused `time` import in `card_get_screen.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892012078a48333823f2c2d8d4bd7c3